### PR TITLE
disable minVer versioning for debug release configuration

### DIFF
--- a/source/Appccelerate.StateMachine/Appccelerate.StateMachine.csproj
+++ b/source/Appccelerate.StateMachine/Appccelerate.StateMachine.csproj
@@ -79,7 +79,7 @@
   </PropertyGroup>
 
   <!-- versioning -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <PackageReference Include="MinVer" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
Measuring on a i7-8750H, 16GB Ram, Samsung 970 Pro System, the before and after difference was roughly 12%.
Tested by running "Measure-Command { foreach ($i in 0..40) { dotnet build -c Debug }}"
Before: 56.3s
After: 49.7s