### PR TITLE
fix #42 AsyncActiveStateMachine.Fire never completes

### DIFF
--- a/source/Appccelerate.StateMachine/Appccelerate.StateMachine.csproj
+++ b/source/Appccelerate.StateMachine/Appccelerate.StateMachine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/source/Appccelerate.StateMachine/AsyncActiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/AsyncActiveStateMachine.cs
@@ -36,7 +36,7 @@ namespace Appccelerate.StateMachine
         private bool pendingInitialization;
         private CancellationTokenSource stopToken;
         private Task worker;
-        private TaskCompletionSource<bool> workerCompletionSource = new TaskCompletionSource<bool>();
+        private TaskCompletionSource<bool> workerCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncActiveStateMachine&lt;TState, TEvent&gt;"/> class.
@@ -250,7 +250,7 @@ namespace Appccelerate.StateMachine
                 }
 
                 await this.workerCompletionSource.Task.ConfigureAwait(false);
-                this.workerCompletionSource = new TaskCompletionSource<bool>();
+                this.workerCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             }
         }
 


### PR DESCRIPTION
To use RunContinuationsAsynchronously we need at least version 1.3 of .Net standard.
Internal behaviour change in case of a single thread: before this fix only ever one event will be enqueued before it is processes. That was because when the workerCompletionSource was set, the awaiting code for the same Task continued synchronously and immediately processed the Event. Only after the processing was done, another event could be enqueued.
After this fix it is possible that multiple events will be enqueued before the first one will be processed. Because the awaiting task will continue asynchronously.