### PR TITLE
Feature/define initial state at configuration time

### DIFF
--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/ExceptionCasesFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/ExceptionCasesFacts.cs
@@ -21,6 +21,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
     using System;
     using System.Threading.Tasks;
     using FluentAssertions;
+    using Infrastructure;
     using StateMachine.AsyncMachine;
     using Xunit;
 
@@ -47,27 +48,12 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
         {
             var stateContainer = new StateContainer<States, Events>();
 
-            Action action = () => { var state = stateContainer.CurrentStateId; };
+            Action action = () => { var state = stateContainer.CurrentStateId.ExtractOrThrow(); };
 
-            action.Should().Throw<NullReferenceException>();
-        }
-
-        [Fact]
-        public async Task ThrowsException_WhenInitializeIsCalledTwice()
-        {
-            var stateContainer = new StateContainer<States, Events>();
-            var testee = new StateMachineBuilder<States, Events>()
-                .WithStateContainer(stateContainer)
-                .Build();
-
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-
-            Func<Task> action = async () =>
-                await testee.Initialize(States.B, stateContainer, stateContainer)
-                    .ConfigureAwait(false);
-
-            action.Should().Throw<InvalidOperationException>();
+            action
+                .Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage(ExceptionMessages.ValueNotInitialized);
         }
 
         [Fact]
@@ -92,9 +78,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
 
             testee.TransitionExceptionThrown += (sender, eventArgs) => { };
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
@@ -103,7 +87,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
             stateContainer
                 .CurrentStateId
                 .Should()
-                .Be(States.A);
+                .BeEquivalentTo(Initializable<States>.Initialized(States.A));
         }
 
         [Fact]
@@ -130,9 +114,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
             testee.TransitionDeclined += (sender, e) => transitionDeclined = true;
             testee.TransitionExceptionThrown += (sender, eventArgs) => { };
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
@@ -173,9 +155,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                     eventArgs.Exception);
             };
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
@@ -209,9 +189,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
 
             testee.TransitionExceptionThrown += (sender, eventArgs) => { };
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
@@ -220,7 +198,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
             stateContainer
                 .CurrentStateId
                 .Should()
-                .Be(States.C);
+                .BeEquivalentTo(Initializable<States>.Initialized(States.C));
         }
 
         [Fact]
@@ -250,9 +228,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                     eventArgs.Exception);
             };
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
@@ -282,9 +258,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
 
             testee.TransitionExceptionThrown += (sender, eventArgs) => { };
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
@@ -293,7 +267,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
             stateContainer
                 .CurrentStateId
                 .Should()
-                .Be(States.B);
+                .BeEquivalentTo(Initializable<States>.Initialized(States.B));
         }
 
         [Fact]
@@ -326,9 +300,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                     eventArgs.Exception);
             };
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
@@ -361,9 +333,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
 
             testee.TransitionExceptionThrown += (sender, eventArgs) => { };
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
@@ -372,7 +342,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
             stateContainer
                 .CurrentStateId
                 .Should()
-                .Be(States.B);
+                .BeEquivalentTo(Initializable<States>.Initialized(States.B));
         }
 
         [Fact]
@@ -403,9 +373,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                     eventArgs.Exception);
             };
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
@@ -436,9 +404,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
 
             testee.TransitionExceptionThrown += (sender, eventArgs) => { };
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
@@ -447,7 +413,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
             stateContainer
                 .CurrentStateId
                 .Should()
-                .Be(States.B);
+                .BeEquivalentTo(Initializable<States>.Initialized(States.B));
         }
 
         [Fact]

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/GuardFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/GuardFacts.cs
@@ -21,6 +21,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
     using System;
     using System.Threading.Tasks;
     using FluentAssertions;
+    using Infrastructure;
     using StateMachine.AsyncMachine;
     using Xunit;
 
@@ -49,9 +50,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             await testee.Fire(Events.A, ExpectedEventArgument, stateContainer, stateContainer, stateDefinitions)
@@ -85,9 +84,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             await testee.Fire(Events.A, ExpectedEventArgument, stateContainer, stateContainer, stateDefinitions)
@@ -114,9 +111,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             await testee.Fire(Events.B, Missing.Value, stateContainer, stateContainer, stateDefinitions)
@@ -125,7 +120,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
             stateContainer
                 .CurrentStateId
                 .Should()
-                .Be(States.B);
+                .BeEquivalentTo(Initializable<States>.Initialized(States.B));
         }
 
         [Fact]
@@ -146,9 +141,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             await testee.Fire(Events.B, 3, stateContainer, stateContainer, stateDefinitions)
@@ -157,7 +150,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
             stateContainer
                 .CurrentStateId
                 .Should()
-                .Be(States.B);
+                .BeEquivalentTo(Initializable<States>.Initialized(States.B));
         }
 
         private static bool SingleIntArgumentGuardReturningTrue(int i)

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Reports/CsvStateMachineReportGeneratorTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Reports/CsvStateMachineReportGeneratorTest.cs
@@ -151,8 +151,6 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Reports
 
             var elevator = createStateMachine("Elevator", stateMachineDefinition);
 
-            elevator.Initialize(States.OnFloor);
-
             elevator.Report(testee);
 
             string statesReport;

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Reports/CsvStateMachineReportGeneratorTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Reports/CsvStateMachineReportGeneratorTest.cs
@@ -146,6 +146,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Reports
                 .In(States.Moving)
                     .On(Events.Stop).Goto(States.OnFloor);
             var stateMachineDefinition = stateMachineDefinitionBuilder
+                .WithInitialState(States.OnFloor)
                 .Build();
 
             var elevator = createStateMachine("Elevator", stateMachineDefinition);

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Reports/StateMachineReportGeneratorTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Reports/StateMachineReportGeneratorTest.cs
@@ -80,7 +80,9 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Reports
             stateMachineDefinitionBuilder
                 .In(States.B2)
                     .On(Events.B1).Goto(States.B2);
-            var stateMachineDefinition = stateMachineDefinitionBuilder.Build();
+            var stateMachineDefinition = stateMachineDefinitionBuilder
+                .WithInitialState(States.A)
+                .Build();
 
             var stateMachine = createStateMachine("Test Machine", stateMachineDefinition);
 

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Reports/StateMachineReportGeneratorTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Reports/StateMachineReportGeneratorTest.cs
@@ -86,8 +86,6 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Reports
 
             var stateMachine = createStateMachine("Test Machine", stateMachineDefinition);
 
-            stateMachine.Initialize(States.A);
-
             var testee = new StateMachineReportGenerator<States, Events>();
             stateMachine.Report(testee);
 

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Reports/YEdStateMachineReportGeneratorTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Reports/YEdStateMachineReportGeneratorTest.cs
@@ -138,7 +138,9 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Reports
                 .In(States.Moving)
                 .On(Events.Stop).Goto(States.OnFloor);
 
-            var stateMachineDefinition = builder.Build();
+            var stateMachineDefinition = builder
+                .WithInitialState(States.OnFloor)
+                .Build();
 
             var elevator = createStateMachine("Elevator", stateMachineDefinition);
 

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Reports/YEdStateMachineReportGeneratorTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Reports/YEdStateMachineReportGeneratorTest.cs
@@ -144,8 +144,6 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Reports
 
             var elevator = createStateMachine("Elevator", stateMachineDefinition);
 
-            elevator.Initialize(States.OnFloor);
-
             var stream = new MemoryStream();
             var textWriter = new StreamWriter(stream);
             var testee = new YEdStateMachineReportGenerator<States, Events>(textWriter);

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/StateActionFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/StateActionFacts.cs
@@ -41,10 +41,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             entered
@@ -70,10 +67,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             entered1.Should().BeTrue("entry action was not executed.");
@@ -98,10 +92,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             receivedValue
@@ -126,9 +117,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             await testee.Fire(Events.B, null, stateContainer, stateContainer, stateDefinitions)
@@ -158,9 +147,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             await testee.Fire(Events.B, null, stateContainer, stateContainer, stateDefinitions)
@@ -189,9 +176,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.Initialize(States.A, stateContainer, stateContainer)
-                .ConfigureAwait(false);
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions)
+            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             await testee.Fire(Events.B, null, stateContainer, stateContainer, stateDefinitions)

--- a/source/Appccelerate.StateMachine.Facts/ExtensionTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/ExtensionTest.cs
@@ -32,33 +32,6 @@ namespace Appccelerate.StateMachine.Facts
     /// </summary>
     public class ExtensionTest
     {
-        /// <summary>
-        /// When the state machine is initialized then the extensions get notified.
-        /// </summary>
-        [Fact]
-        public void Initialize()
-        {
-            var initialState = States.A;
-
-            var information = A.Fake<IStateMachineInformation<States, Events>>();
-            var extension = A.Fake<IExtension<States, Events>>();
-            var stateContainer = new StateContainer<States, Events>();
-            stateContainer.Extensions.Add(extension);
-
-            var standardFactory = new StandardFactory<States, Events>();
-            var testee = new StateMachine<States, Events>(
-                standardFactory,
-                A.Fake<IStateLogic<States, Events>>());
-
-            testee.Initialize(initialState, stateContainer, information);
-
-            A.CallTo(() => extension.InitializingStateMachine(information, ref initialState))
-                .MustHaveHappened();
-
-            A.CallTo(() => extension.InitializedStateMachine(information, initialState))
-                .MustHaveHappened();
-        }
-
         [Fact]
         public void EnterInitialState()
         {
@@ -77,8 +50,7 @@ namespace Appccelerate.StateMachine.Facts
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(InitialState, stateContainer, information);
-            testee.EnterInitialState(stateContainer, information, stateDefinitions);
+            testee.EnterInitialState(stateContainer, information, stateDefinitions, InitialState);
 
             A.CallTo(() => extension.EnteringInitialState(information, InitialState))
                 .MustHaveHappened();
@@ -88,38 +60,6 @@ namespace Appccelerate.StateMachine.Facts
                     InitialState,
                     A<ITransitionContext<States, Events>>.That.Matches(context => context.StateDefinition == null)))
                 .MustHaveHappened();
-        }
-
-        /// <summary>
-        /// An extension can override the state to which the state machine is initialized.
-        /// </summary>
-        [Fact]
-        public void OverrideInitialState()
-        {
-            var overrideExtension = new OverrideExtension { OverriddenState = States.B };
-            var stateContainer = new StateContainer<States, Events>();
-            stateContainer.Extensions.Add(overrideExtension);
-
-            var stateDefinitionsBuilder = new StateDefinitionsBuilder<States, Events>();
-            stateDefinitionsBuilder.In(States.A);
-            stateDefinitionsBuilder.In(States.B);
-            var stateDefinitions = stateDefinitionsBuilder.Build();
-
-            var testee = new StateMachineBuilder<States, Events>()
-                .WithStateContainer(stateContainer)
-                .Build();
-
-            testee.Initialize(
-                States.A,
-                stateContainer,
-                A.Fake<IStateMachineInformation<States, Events>>());
-
-            testee.EnterInitialState(
-                stateContainer,
-                A.Fake<IStateMachineInformation<States, Events>>(),
-                stateDefinitions);
-
-            stateContainer.CurrentStateId.Should().Be(States.B);
         }
 
         /// <summary>
@@ -143,8 +83,7 @@ namespace Appccelerate.StateMachine.Facts
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             var eventId = Events.B;
             var eventArgument = new object();
@@ -187,8 +126,7 @@ namespace Appccelerate.StateMachine.Facts
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             const Events NewEvent = Events.C;
             var newEventArgument = new object();
@@ -226,8 +164,7 @@ namespace Appccelerate.StateMachine.Facts
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(Source, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Event, stateContainer, stateContainer, stateDefinitions);
 
@@ -274,8 +211,7 @@ namespace Appccelerate.StateMachine.Facts
 
             testee.TransitionExceptionThrown += (s, e) => { };
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, stateContainer, stateContainer, stateDefinitions);
 
@@ -323,8 +259,7 @@ namespace Appccelerate.StateMachine.Facts
 
             testee.TransitionExceptionThrown += (s, e) => { };
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             overrideExtension.OverriddenException = overriddenException;
 
@@ -363,8 +298,7 @@ namespace Appccelerate.StateMachine.Facts
 
             testee.TransitionExceptionThrown += (s, e) => { };
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, stateContainer, stateContainer, stateDefinitions);
 
@@ -411,8 +345,7 @@ namespace Appccelerate.StateMachine.Facts
 
             testee.TransitionExceptionThrown += (s, e) => { };
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             overrideExtension.OverriddenException = overriddenException;
 
@@ -454,8 +387,7 @@ namespace Appccelerate.StateMachine.Facts
 
             testee.TransitionExceptionThrown += (s, e) => { };
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, stateContainer, stateContainer, stateDefinitions);
 
@@ -505,8 +437,7 @@ namespace Appccelerate.StateMachine.Facts
 
             testee.TransitionExceptionThrown += (s, e) => { };
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             overrideExtension.OverriddenException = overriddenException;
 
@@ -546,8 +477,7 @@ namespace Appccelerate.StateMachine.Facts
 
             testee.TransitionExceptionThrown += (s, e) => { };
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, stateContainer, stateContainer, stateDefinitions);
 
@@ -595,8 +525,7 @@ namespace Appccelerate.StateMachine.Facts
 
             testee.TransitionExceptionThrown += (s, e) => { };
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             overrideExtension.OverriddenException = overriddenException;
 
@@ -634,8 +563,7 @@ namespace Appccelerate.StateMachine.Facts
 
             testee.TransitionExceptionThrown += (s, e) => { };
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             A.CallTo(() => extension.HandlingEntryActionException(
                     stateContainer,
@@ -676,14 +604,6 @@ namespace Appccelerate.StateMachine.Facts
             public object OverriddenEventArgument { get; set; }
 
             public Exception OverriddenException { get; set; }
-
-            public override void InitializingStateMachine(IStateMachineInformation<States, Events> stateMachine, ref States initialState)
-            {
-                if (this.OverriddenState.HasValue)
-                {
-                    initialState = this.OverriddenState.Value;
-                }
-            }
 
             public override void FiringEvent(IStateMachineInformation<States, Events> stateMachine, ref Events eventId, ref object eventArgument)
             {

--- a/source/Appccelerate.StateMachine.Facts/Machine/ActivePassiveStateMachineTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/ActivePassiveStateMachineTest.cs
@@ -64,19 +64,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .Should().BeTrue();
         }
 
-        [Fact]
-        public void BuildingAStateMachineWithoutInitialStateThenInvalidOperationException()
-        {
-            var testee = new StateMachineDefinitionBuilder<States, Events>();
-
-            Action action = () => testee.Build();
-
-            action
-                .Should()
-                .Throw<InvalidOperationException>()
-                .WithMessage("Initial state is not configured.");
-        }
-
         /// <summary>
         /// The <see cref="IStateMachine{TState,TEvent}.IsRunning"/> reflects the state of the state machine.
         /// </summary>

--- a/source/Appccelerate.StateMachine.Facts/Machine/ActivePassiveStateMachineTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/ActivePassiveStateMachineTest.cs
@@ -315,7 +315,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var extension = A.Fake<IExtension<States, Events>>();
 
             A.CallTo(() => loader.LoadCurrentState())
-                .Returns(new Initializable<States> { Value = States.C });
+                .Returns(Initializable<States>.Initialized(States.C));
 
             var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<States, Events>();
             stateMachineDefinitionBuilder
@@ -336,7 +336,9 @@ namespace Appccelerate.StateMachine.Facts.Machine
                         A<IStateMachineInformation<States, Events>>.Ignored,
                         A<Initializable<States>>
                             .That
-                            .Matches(x => x.Value == States.C),
+                            .Matches(currentState =>
+                                currentState.IsInitialized
+                                && currentState.ExtractOrThrow() == States.C),
                         A<IReadOnlyDictionary<States, States>>.Ignored))
                 .MustHaveHappenedOnceExactly();
         }

--- a/source/Appccelerate.StateMachine.Facts/Machine/ActivePassiveStateMachineTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/ActivePassiveStateMachineTest.cs
@@ -44,27 +44,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
 
         [Theory]
         [MemberData(nameof(StateMachineInstantiationProvider))]
-        public void InitializeWhenNotStartedThenNoStateIsEntered(string dummyName, Func<StateMachineDefinition<States, Events>, IStateMachine<States, Events>> createStateMachine)
-        {
-            var enteredState = false;
-
-            var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<States, Events>();
-            stateMachineDefinitionBuilder
-                .In(States.A)
-                    .ExecuteOnEntry(() => enteredState = true);
-            var stateMachineDefinition = stateMachineDefinitionBuilder.Build();
-
-            var testee = createStateMachine(stateMachineDefinition);
-
-            testee.Initialize(States.A);
-
-            enteredState
-                .Should().BeFalse();
-        }
-
-        [Theory]
-        [MemberData(nameof(StateMachineInstantiationProvider))]
-        public void InitializeWhenStartedThenInitialStateIsEntered(string dummyName, Func<StateMachineDefinition<States, Events>, IStateMachine<States, Events>> createStateMachine)
+        public void StartThenInitialStateIsEntered(string dummyName, Func<StateMachineDefinition<States, Events>, IStateMachine<States, Events>> createStateMachine)
         {
             var enteredStateSignal = new AutoResetEvent(false);
 
@@ -72,47 +52,29 @@ namespace Appccelerate.StateMachine.Facts.Machine
             stateMachineDefinitionBuilder
                 .In(States.A)
                     .ExecuteOnEntry(() => enteredStateSignal.Set());
-            var stateMachineDefinition = stateMachineDefinitionBuilder.Build();
+            var stateMachineDefinition = stateMachineDefinitionBuilder
+                .WithInitialState(States.A)
+                .Build();
 
             var testee = createStateMachine(stateMachineDefinition);
 
-            testee.Initialize(States.A);
             testee.Start();
 
             enteredStateSignal.WaitOne(1000)
                 .Should().BeTrue();
         }
 
-        [Theory]
-        [MemberData(nameof(StateMachineInstantiationProvider))]
-        public void InitializeWhenInitializedTwiceThenInvalidOperationException(string dummyName, Func<StateMachineDefinition<States, Events>, IStateMachine<States, Events>> createStateMachine)
+        [Fact]
+        public void BuildingAStateMachineWithoutInitialStateThenInvalidOperationException()
         {
-            var stateMachineDefinition = new StateMachineDefinitionBuilder<States, Events>()
-                .Build();
+            var testee = new StateMachineDefinitionBuilder<States, Events>();
 
-            var testee = createStateMachine(stateMachineDefinition);
-
-            testee.Initialize(States.A);
-            Action action = () => testee.Initialize(States.A);
-
-            action.Should()
-                .Throw<InvalidOperationException>()
-                .WithMessage(ExceptionMessages.StateMachineIsAlreadyInitialized);
-        }
-
-        [Theory]
-        [MemberData(nameof(StateMachineInstantiationProvider))]
-        public void StartingAnUninitializedStateMachineThenInvalidOperationException(string dummyName, Func<StateMachineDefinition<States, Events>, IStateMachine<States, Events>> createStateMachine)
-        {
-            var stateMachineDefinition = new StateMachineDefinitionBuilder<States, Events>()
-                .Build();
-
-            var testee = createStateMachine(stateMachineDefinition);
-
-            Action action = () => testee.Start();
+            Action action = () => testee.Build();
 
             action
-                .Should().Throw<InvalidOperationException>();
+                .Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("Initial state is not configured.");
         }
 
         /// <summary>
@@ -127,11 +89,11 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<States, Events>();
             stateMachineDefinitionBuilder
                 .In(States.A);
-            var stateMachineDefinition = stateMachineDefinitionBuilder.Build();
+            var stateMachineDefinition = stateMachineDefinitionBuilder
+                .WithInitialState(States.A)
+                .Build();
 
             var testee = createStateMachine(stateMachineDefinition);
-
-            testee.Initialize(States.A);
 
             var runningInitially = testee.IsRunning;
             testee.Start();
@@ -187,7 +149,9 @@ namespace Appccelerate.StateMachine.Facts.Machine
             stateMachineDefinitionBuilder
                 .In(States.A)
                     .On(Events.B).Goto(States.B);
-            var stateMachineDefinition = stateMachineDefinitionBuilder.Build();
+            var stateMachineDefinition = stateMachineDefinitionBuilder
+                .WithInitialState(States.A)
+                .Build();
 
             var testee = createStateMachine(stateMachineDefinition);
 
@@ -200,7 +164,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
 
             object eventArgument = "test";
 
-            testee.Initialize(States.A);
             testee.Start();
 
             testee.Fire(Events.B, eventArgument);
@@ -253,7 +216,9 @@ namespace Appccelerate.StateMachine.Facts.Machine
             stateMachineDefinitionBuilder
                 .In(States.C)
                     .On(Events.D).Goto(States.D);
-            var stateMachineDefinition = stateMachineDefinitionBuilder.Build();
+            var stateMachineDefinition = stateMachineDefinitionBuilder
+                .WithInitialState(States.A)
+                .Build();
 
             testee = createStateMachine(stateMachineDefinition);
 
@@ -266,7 +231,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
 
             var allTransitionsCompleted = SetUpWaitForAllTransitions(testee, 1);
 
-            testee.Initialize(States.A);
             testee.Start();
 
             testee.Fire(Events.B);
@@ -301,7 +265,9 @@ namespace Appccelerate.StateMachine.Facts.Machine
             stateMachineDefinitionBuilder
                 .In(States.B)
                     .On(Events.C).Goto(States.C);
-            var stateMachineDefinition = stateMachineDefinitionBuilder.Build();
+            var stateMachineDefinition = stateMachineDefinitionBuilder
+                .WithInitialState(States.A)
+                .Build();
 
             var testee = createStateMachine(stateMachineDefinition);
 
@@ -310,7 +276,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
 
             var allTransitionsCompleted = SetUpWaitForAllTransitions(testee, 1);
 
-            testee.Initialize(States.A);
             testee.Start();
 
             testee.Stop();
@@ -343,11 +308,11 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<States, Events>();
             stateMachineDefinitionBuilder
                 .In(States.A);
-            var stateMachineDefinition = stateMachineDefinitionBuilder.Build();
+            var stateMachineDefinition = stateMachineDefinitionBuilder
+                .WithInitialState(States.A)
+                .Build();
 
             var testee = createStateMachine(stateMachineDefinition);
-
-            testee.Initialize(States.A);
 
             testee.Start();
             testee.Start();
@@ -370,7 +335,9 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .In(States.A);
             stateMachineDefinitionBuilder
                 .In(States.C);
-            var stateMachineDefinition = stateMachineDefinitionBuilder.Build();
+            var stateMachineDefinition = stateMachineDefinitionBuilder
+                .WithInitialState(States.A)
+                .Build();
 
             var testee = createStateMachine(stateMachineDefinition);
             testee.AddExtension(extension);
@@ -407,6 +374,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                     .ExecuteOnExit(() => exitedD2 = true)
                     .On(Events.A).Goto(States.A);
             var testee = stateMachineDefinitionBuilder
+                .WithInitialState(States.A)
                 .Build()
                 .CreatePassiveStateMachine();
 
@@ -419,7 +387,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 });
 
             testee.Load(loader);
-            testee.Initialize(States.A);
             testee.Start();
             testee.Fire(Events.D); // should go to loaded last active state D2, not initial state D1
             exitedD2 = false;
@@ -430,15 +397,50 @@ namespace Appccelerate.StateMachine.Facts.Machine
             exitedD2.Should().BeTrue();
         }
 
-        [Theory]
-        [MemberData(nameof(StateMachineInstantiationProvider))]
-        public void ThrowsExceptionOnLoading_WhenAlreadyInitialized(string dummyName, Func<StateMachineDefinition<States, Events>, IStateMachine<States, Events>> createStateMachine)
+        [Fact]
+        public void PassiveStateMachineThrowsExceptionOnLoading_WhenAlreadyStarted()
         {
-            var stateMachineDefinition = new StateMachineDefinitionBuilder<States, Events>()
-               .Build();
+            var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<States, Events>();
+            stateMachineDefinitionBuilder.In(States.A);
+            var testee = stateMachineDefinitionBuilder
+                .WithInitialState(States.A)
+                .Build()
+                .CreatePassiveStateMachine();
 
-            var testee = createStateMachine(stateMachineDefinition);
-            testee.Initialize(States.A);
+            testee.Start();
+
+            Action action = () => testee.Load(A.Fake<IStateMachineLoader<States>>());
+
+            action
+                .Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage(ExceptionMessages.StateMachineIsAlreadyInitialized);
+        }
+
+        [Fact]
+        public void ThrowsExceptionOnLoading_WhenAlreadyStarted()
+        {
+            var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<States, Events>();
+            stateMachineDefinitionBuilder.In(States.A);
+            var testee = stateMachineDefinitionBuilder
+                .WithInitialState(States.A)
+                .Build()
+                .CreateActiveStateMachine();
+
+            var signal = new AutoResetEvent(false);
+            var extension = A.Fake<IExtension<States, Events>>();
+            A.CallTo(() =>
+                    extension.EnteredInitialState(
+                        A<IStateMachineInformation<States, Events>>.Ignored,
+                        A<States>.Ignored,
+                        A<ITransitionContext<States, Events>>.Ignored))
+                .Invokes(() => signal.Set());
+            testee.AddExtension(extension);
+
+            testee.Start();
+
+            var stateMachineWasStarted = signal.WaitOne(500);
+            stateMachineWasStarted.Should().BeTrue();
 
             Action action = () => testee.Load(A.Fake<IStateMachineLoader<States>>());
 
@@ -460,7 +462,9 @@ namespace Appccelerate.StateMachine.Facts.Machine
                     .WithHistoryType(HistoryType.Deep)
                     .WithInitialSubState(States.B1)
                     .WithSubState(States.B2);
-            var stateMachineDefinition = stateMachineDefinitionBuilder.Build();
+            var stateMachineDefinition = stateMachineDefinitionBuilder
+                .WithInitialState(States.A)
+                .Build();
 
             var testee = createStateMachine(stateMachineDefinition);
 

--- a/source/Appccelerate.StateMachine.Facts/Machine/ExceptionCasesTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/ExceptionCasesTest.cs
@@ -21,6 +21,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
     using System;
     using Appccelerate.StateMachine.Machine;
     using FluentAssertions;
+    using Infrastructure;
     using Xunit;
 
     /// <summary>
@@ -50,28 +51,12 @@ namespace Appccelerate.StateMachine.Facts.Machine
         {
             var stateContainer = new StateContainer<States, Events>();
 
-            Action action = () => { var state = stateContainer.CurrentStateId; };
+            Action action = () => { var state = stateContainer.CurrentStateIdNew.Value; };
 
-            action.Should().Throw<NullReferenceException>();
-        }
-
-        /// <summary>
-        /// When the state machine is initialized twice then an exception is thrown.
-        /// </summary>
-        [Fact]
-        public void ExceptionIfInitializeIsCalledTwice()
-        {
-            var stateContainer = new StateContainer<States, Events>();
-
-            var testee = new StateMachineBuilder<States, Events>()
-                .WithStateContainer(stateContainer)
-                .Build();
-
-            testee.Initialize(States.A, stateContainer, stateContainer);
-
-            Action action = () => testee.Initialize(States.B, stateContainer, stateContainer);
-
-            action.Should().Throw<InvalidOperationException>();
+            action
+                .Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage(ExceptionMessages.ValueNotInitialized);
         }
 
         /// <summary>
@@ -111,8 +96,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 recordedException = eventArgs.Exception;
             };
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions);
 
@@ -120,7 +104,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             recordedEventId.Should().Be(Events.B);
             recordedEventArgument.Should().Be(eventArguments);
             recordedException.Should().Be(exception);
-            stateContainer.CurrentStateId.Should().Be(States.A);
+            stateContainer.CurrentStateIdNew.Should().BeEquivalentTo(Initializable<States>.Initialized(States.A));
             transitionDeclined.Should().BeTrue("transition was not declined.");
         }
 
@@ -160,8 +144,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 recordedException = eventArgs.Exception;
             };
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions);
 
@@ -169,7 +152,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             recordedEventId.Should().Be(Events.B);
             recordedEventArgument.Should().Be(eventArguments);
             recordedException.Should().Be(exception);
-            stateContainer.CurrentStateId.Should().Be(States.B);
+            stateContainer.CurrentStateIdNew.Should().BeEquivalentTo(Initializable<States>.Initialized(States.B));
         }
 
         [Fact]
@@ -206,8 +189,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 recordedException = eventArgs.Exception;
             };
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions);
 
@@ -215,7 +197,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             recordedEventId.Should().Be(Events.B);
             recordedEventArgument.Should().Be(eventArguments);
             recordedException.Should().Be(exception);
-            stateContainer.CurrentStateId.Should().Be(States.B);
+            stateContainer.CurrentStateIdNew.Should().BeEquivalentTo(Initializable<States>.Initialized(States.B));
         }
 
         [Fact]
@@ -250,15 +232,14 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 recordedException = eventArgs.Exception;
             };
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions);
             recordedStateId.Should().Be(States.A);
             recordedEventId.Should().Be(Events.B);
             recordedEventArgument.Should().Be(eventArguments);
             recordedException.Should().Be(exception);
-            stateContainer.CurrentStateId.Should().Be(States.B);
+            stateContainer.CurrentStateIdNew.Should().BeEquivalentTo(Initializable<States>.Initialized(States.B));
         }
 
         /// <summary>

--- a/source/Appccelerate.StateMachine.Facts/Machine/ExceptionCasesTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/ExceptionCasesTest.cs
@@ -51,7 +51,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
         {
             var stateContainer = new StateContainer<States, Events>();
 
-            Action action = () => { var state = stateContainer.CurrentStateIdNew.Value; };
+            Action action = () => { var state = stateContainer.CurrentStateIdNew.ExtractOrThrow(); };
 
             action
                 .Should()

--- a/source/Appccelerate.StateMachine.Facts/Machine/ExceptionCasesTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/ExceptionCasesTest.cs
@@ -51,7 +51,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
         {
             var stateContainer = new StateContainer<States, Events>();
 
-            Action action = () => { var state = stateContainer.CurrentStateIdNew.ExtractOrThrow(); };
+            Action action = () => { var state = stateContainer.CurrentStateId.ExtractOrThrow(); };
 
             action
                 .Should()
@@ -104,7 +104,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             recordedEventId.Should().Be(Events.B);
             recordedEventArgument.Should().Be(eventArguments);
             recordedException.Should().Be(exception);
-            stateContainer.CurrentStateIdNew.Should().BeEquivalentTo(Initializable<States>.Initialized(States.A));
+            stateContainer.CurrentStateId.Should().BeEquivalentTo(Initializable<States>.Initialized(States.A));
             transitionDeclined.Should().BeTrue("transition was not declined.");
         }
 
@@ -152,7 +152,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             recordedEventId.Should().Be(Events.B);
             recordedEventArgument.Should().Be(eventArguments);
             recordedException.Should().Be(exception);
-            stateContainer.CurrentStateIdNew.Should().BeEquivalentTo(Initializable<States>.Initialized(States.B));
+            stateContainer.CurrentStateId.Should().BeEquivalentTo(Initializable<States>.Initialized(States.B));
         }
 
         [Fact]
@@ -197,7 +197,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             recordedEventId.Should().Be(Events.B);
             recordedEventArgument.Should().Be(eventArguments);
             recordedException.Should().Be(exception);
-            stateContainer.CurrentStateIdNew.Should().BeEquivalentTo(Initializable<States>.Initialized(States.B));
+            stateContainer.CurrentStateId.Should().BeEquivalentTo(Initializable<States>.Initialized(States.B));
         }
 
         [Fact]
@@ -239,7 +239,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             recordedEventId.Should().Be(Events.B);
             recordedEventArgument.Should().Be(eventArguments);
             recordedException.Should().Be(exception);
-            stateContainer.CurrentStateIdNew.Should().BeEquivalentTo(Initializable<States>.Initialized(States.B));
+            stateContainer.CurrentStateId.Should().BeEquivalentTo(Initializable<States>.Initialized(States.B));
         }
 
         /// <summary>

--- a/source/Appccelerate.StateMachine.Facts/Machine/GuardTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/GuardTest.cs
@@ -19,6 +19,7 @@
 namespace Appccelerate.StateMachine.Facts.Machine
 {
     using FluentAssertions;
+    using Infrastructure;
     using StateMachine.Machine;
     using Xunit;
 
@@ -51,8 +52,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.A, EventArgument, stateContainer, stateContainer, stateDefinitions);
 
@@ -77,12 +77,14 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, stateContainer, stateContainer, stateDefinitions);
 
-            stateContainer.CurrentStateId.Should().Be(States.B);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.B));
         }
 
         [Fact]
@@ -104,12 +106,14 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, 3, stateContainer, stateContainer, stateDefinitions);
 
-            stateContainer.CurrentStateId.Should().Be(States.B);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.B));
         }
 
         private static bool SingleIntArgumentGuardReturningTrue(int i)

--- a/source/Appccelerate.StateMachine.Facts/Machine/GuardTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/GuardTest.cs
@@ -82,7 +82,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             testee.Fire(Events.B, stateContainer, stateContainer, stateDefinitions);
 
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.B));
         }
@@ -111,7 +111,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             testee.Fire(Events.B, 3, stateContainer, stateContainer, stateDefinitions);
 
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.B));
         }

--- a/source/Appccelerate.StateMachine.Facts/Machine/Reports/CsvStateMachineReportGeneratorTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Reports/CsvStateMachineReportGeneratorTest.cs
@@ -146,11 +146,10 @@ namespace Appccelerate.StateMachine.Facts.Machine.Reports
                 .In(States.Moving)
                     .On(Events.Stop).Goto(States.OnFloor);
             var stateMachineDefinition = stateMachineDefinitionBuilder
+                .WithInitialState(States.OnFloor)
                 .Build();
 
             var elevator = createStateMachine("Elevator", stateMachineDefinition);
-
-            elevator.Initialize(States.OnFloor);
 
             elevator.Report(testee);
 

--- a/source/Appccelerate.StateMachine.Facts/Machine/Reports/StateMachineReportGeneratorTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Reports/StateMachineReportGeneratorTest.cs
@@ -80,11 +80,11 @@ namespace Appccelerate.StateMachine.Facts.Machine.Reports
             stateMachineDefinitionBuilder
                 .In(States.B2)
                     .On(Events.B1).Goto(States.B2);
-            var stateMachineDefinition = stateMachineDefinitionBuilder.Build();
+            var stateMachineDefinition = stateMachineDefinitionBuilder
+                .WithInitialState(States.A)
+                .Build();
 
             var stateMachine = createStateMachine("Test Machine", stateMachineDefinition);
-
-            stateMachine.Initialize(States.A);
 
             var testee = new StateMachineReportGenerator<States, Events>();
             stateMachine.Report(testee);

--- a/source/Appccelerate.StateMachine.Facts/Machine/Reports/YEdStateMachineReportGeneratorTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Reports/YEdStateMachineReportGeneratorTest.cs
@@ -138,11 +138,11 @@ namespace Appccelerate.StateMachine.Facts.Machine.Reports
                 .In(States.Moving)
                 .On(Events.Stop).Goto(States.OnFloor);
 
-            var stateMachineDefinition = builder.Build();
+            var stateMachineDefinition = builder
+                .WithInitialState(States.OnFloor)
+                .Build();
 
             var elevator = createStateMachine("Elevator", stateMachineDefinition);
-
-            elevator.Initialize(States.OnFloor);
 
             var stream = new MemoryStream();
             var textWriter = new StreamWriter(stream);

--- a/source/Appccelerate.StateMachine.Facts/Machine/StateActionTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/StateActionTest.cs
@@ -43,9 +43,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             entered.Should().BeTrue("entry action was not executed.");
         }
@@ -68,9 +66,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             entered1.Should().BeTrue("entry action was not executed.");
             entered2.Should().BeTrue("entry action was not executed.");
@@ -94,9 +90,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             receivedValue.Should().Be(Parameter);
         }
@@ -118,8 +112,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, stateContainer, stateContainer, stateDefinitions);
 
@@ -145,8 +138,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, stateContainer, stateContainer, stateDefinitions);
 
@@ -173,8 +165,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, stateContainer, stateContainer, stateDefinitions);
 

--- a/source/Appccelerate.StateMachine.Facts/Machine/StateMachineTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/StateMachineTest.cs
@@ -23,6 +23,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
     using System.Linq;
     using System.Text;
     using FluentAssertions;
+    using Infrastructure;
     using StateMachine.Machine;
     using Xunit;
 
@@ -148,14 +149,17 @@ namespace Appccelerate.StateMachine.Facts.Machine
         }
 
         [Fact]
-        public void InitializationWhenInitialStateIsNotYetEnteredThenNoActionIsPerformed()
+        public void CurrentStateShouldBeUninitializedWhenInitialStateWasNotYetEntered()
         {
             var stateContainer = new StateContainer<States, Events>();
-            var testee = new StateMachineBuilder<States, Events>()
+            new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .Match<Initializable<States>>(x => x.IsInitialized == false);
 
             this.CheckNoRemainingRecords();
         }
@@ -171,10 +175,12 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.A);
 
-            stateContainer.CurrentStateId.Should().Be(States.A);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.A));
 
             this.CheckRecord<EntryRecord>(States.A);
             this.CheckNoRemainingRecords();
@@ -192,10 +198,12 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.D1B, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.D1B);
 
-            stateContainer.CurrentStateId.Should().Be(States.D1B);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.D1B));
 
             this.CheckRecord<EntryRecord>(States.D);
             this.CheckRecord<EntryRecord>(States.D1);
@@ -218,10 +226,12 @@ namespace Appccelerate.StateMachine.Facts.Machine
             stateContainer.SetLastActiveStateFor(States.D, this.stateDefinitions[States.D1]);
             stateContainer.SetLastActiveStateFor(States.D1, this.stateDefinitions[States.D1A]);
 
-            testee.Initialize(States.D, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.D);
 
-            stateContainer.CurrentStateId.Should().Be(States.D1A);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.D1A));
 
             this.CheckRecord<EntryRecord>(States.D);
             this.CheckRecord<EntryRecord>(States.D1);
@@ -243,14 +253,16 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.E, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.E);
 
             this.ClearRecords();
 
             testee.Fire(Events.A, stateContainer, stateContainer, this.stateDefinitions);
 
-            stateContainer.CurrentStateId.Should().Be(States.A);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.A));
 
             this.CheckRecord<ExitRecord>(States.E);
             this.CheckRecord<EntryRecord>(States.A);
@@ -270,14 +282,16 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.B1, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.B1);
 
             this.ClearRecords();
 
             testee.Fire(Events.B2, stateContainer, stateContainer, this.stateDefinitions);
 
-            stateContainer.CurrentStateId.Should().Be(States.B2);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.B2));
 
             this.CheckRecord<ExitRecord>(States.B1);
             this.CheckRecord<EntryRecord>(States.B2);
@@ -297,14 +311,16 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.B2, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.B2);
 
             this.ClearRecords();
 
             testee.Fire(Events.C1B, stateContainer, stateContainer, this.stateDefinitions);
 
-            stateContainer.CurrentStateId.Should().Be(States.C1B);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.C1B));
 
             this.CheckRecord<ExitRecord>(States.B2);
             this.CheckRecord<ExitRecord>(States.B);
@@ -327,14 +343,16 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.D1B, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.D1B);
 
             this.ClearRecords();
 
             testee.Fire(Events.B1, stateContainer, stateContainer, this.stateDefinitions);
 
-            stateContainer.CurrentStateId.Should().Be(States.B1);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.B1));
 
             this.CheckRecord<ExitRecord>(States.D1B);
             this.CheckRecord<ExitRecord>(States.D1);
@@ -357,14 +375,16 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.A);
 
             this.ClearRecords();
 
             testee.Fire(Events.B, stateContainer, stateContainer, this.stateDefinitions);
 
-            stateContainer.CurrentStateId.Should().Be(States.B1);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.B1));
 
             this.CheckRecord<ExitRecord>(States.A);
             this.CheckRecord<EntryRecord>(States.B);
@@ -384,8 +404,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.B2, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.B2);
             testee.Fire(Events.A, stateContainer, stateContainer, this.stateDefinitions);
 
             this.ClearRecords();
@@ -410,15 +429,17 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.C1B, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.C1B);
             testee.Fire(Events.A, stateContainer, stateContainer, this.stateDefinitions);
 
             this.ClearRecords();
 
             testee.Fire(Events.C, stateContainer, stateContainer, this.stateDefinitions);
 
-            stateContainer.CurrentStateId.Should().Be(States.C1A);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.C1A));
 
             this.CheckRecord<ExitRecord>(States.A);
             this.CheckRecord<EntryRecord>(States.C);
@@ -439,15 +460,17 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.D1B, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.D1B);
             testee.Fire(Events.A, stateContainer, stateContainer, this.stateDefinitions);
 
             this.ClearRecords();
 
             testee.Fire(Events.D, stateContainer, stateContainer, this.stateDefinitions);
 
-            stateContainer.CurrentStateId.Should().Be(States.D1B);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.D1B));
 
             this.CheckRecord<ExitRecord>(States.A);
             this.CheckRecord<EntryRecord>(States.D);
@@ -467,14 +490,16 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.C1B, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.C1B);
 
             this.ClearRecords();
 
             testee.Fire(Events.A, stateContainer, stateContainer, this.stateDefinitions);
 
-            stateContainer.CurrentStateId.Should().Be(States.A);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.A));
 
             this.CheckRecord<ExitRecord>(States.C1B);
             this.CheckRecord<ExitRecord>(States.C1);
@@ -494,13 +519,15 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.A);
             this.ClearRecords();
 
             testee.Fire(Events.A, stateContainer, stateContainer, this.stateDefinitions);
 
-            stateContainer.CurrentStateId.Should().Be(States.A);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.A));
         }
 
         [Fact]
@@ -511,13 +538,15 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.E, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.E);
             this.ClearRecords();
 
             testee.Fire(Events.E, stateContainer, stateContainer, this.stateDefinitions);
 
-            stateContainer.CurrentStateId.Should().Be(States.E);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.E));
 
             this.CheckRecord<ExitRecord>(States.E);
             this.CheckRecord<EntryRecord>(States.E);
@@ -532,13 +561,15 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.C1A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.C1A);
             this.ClearRecords();
 
             testee.Fire(Events.C1B, stateContainer, stateContainer, this.stateDefinitions);
 
-            stateContainer.CurrentStateId.Should().Be(States.C1B);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.C1B));
 
             this.CheckRecord<ExitRecord>(States.C1A);
             this.CheckRecord<EntryRecord>(States.C1B);

--- a/source/Appccelerate.StateMachine.Facts/Machine/StateMachineTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/StateMachineTest.cs
@@ -157,7 +157,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .Build();
 
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .Match<Initializable<States>>(x => x.IsInitialized == false);
 
@@ -178,7 +178,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.A);
 
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.A));
 
@@ -201,7 +201,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.D1B);
 
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.D1B));
 
@@ -229,7 +229,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.D);
 
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.D1A));
 
@@ -260,7 +260,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             testee.Fire(Events.A, stateContainer, stateContainer, this.stateDefinitions);
 
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.A));
 
@@ -289,7 +289,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             testee.Fire(Events.B2, stateContainer, stateContainer, this.stateDefinitions);
 
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.B2));
 
@@ -318,7 +318,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             testee.Fire(Events.C1B, stateContainer, stateContainer, this.stateDefinitions);
 
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.C1B));
 
@@ -350,7 +350,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             testee.Fire(Events.B1, stateContainer, stateContainer, this.stateDefinitions);
 
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.B1));
 
@@ -382,7 +382,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             testee.Fire(Events.B, stateContainer, stateContainer, this.stateDefinitions);
 
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.B1));
 
@@ -437,7 +437,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             testee.Fire(Events.C, stateContainer, stateContainer, this.stateDefinitions);
 
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.C1A));
 
@@ -468,7 +468,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             testee.Fire(Events.D, stateContainer, stateContainer, this.stateDefinitions);
 
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.D1B));
 
@@ -497,7 +497,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             testee.Fire(Events.A, stateContainer, stateContainer, this.stateDefinitions);
 
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.A));
 
@@ -525,7 +525,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             testee.Fire(Events.A, stateContainer, stateContainer, this.stateDefinitions);
 
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.A));
         }
@@ -544,7 +544,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             testee.Fire(Events.E, stateContainer, stateContainer, this.stateDefinitions);
 
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.E));
 
@@ -567,7 +567,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             testee.Fire(Events.C1B, stateContainer, stateContainer, this.stateDefinitions);
 
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.C1B));
 

--- a/source/Appccelerate.StateMachine.Facts/Machine/TransitionsTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/TransitionsTest.cs
@@ -19,6 +19,7 @@
 namespace Appccelerate.StateMachine.Facts.Machine
 {
     using FluentAssertions;
+    using Infrastructure;
     using StateMachine.Machine;
     using Xunit;
 
@@ -51,13 +52,15 @@ namespace Appccelerate.StateMachine.Facts.Machine
 
             testee.TransitionDeclined += (sender, e) => { declined = true; };
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.C, stateContainer, stateContainer, stateDefinitions);
 
             declined.Should().BeTrue("Declined event was not fired");
-            stateContainer.CurrentStateId.Should().Be(States.A);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.A));
         }
 
         /// <summary>
@@ -85,8 +88,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, EventArgument, stateContainer, stateContainer, stateDefinitions);
 
@@ -116,8 +118,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, EventArgument, stateContainer, stateContainer, stateDefinitions);
 
@@ -147,13 +148,15 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.A, stateContainer, stateContainer, stateDefinitions);
 
             executed.Should().BeTrue("internal transition was not executed.");
-            stateContainer.CurrentStateId.Should().Be(States.A);
+            stateContainer
+                .CurrentStateIdNew
+                .Should()
+                .BeEquivalentTo(Initializable<States>.Initialized(States.A));
         }
 
         [Fact]
@@ -173,8 +176,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, stateContainer, stateContainer, stateDefinitions);
 
@@ -199,8 +201,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.Initialize(States.A, stateContainer, stateContainer);
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions);
+            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, ExpectedValue, stateContainer, stateContainer, stateDefinitions);
 

--- a/source/Appccelerate.StateMachine.Facts/Machine/TransitionsTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/TransitionsTest.cs
@@ -58,7 +58,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
 
             declined.Should().BeTrue("Declined event was not fired");
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.A));
         }
@@ -154,7 +154,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
 
             executed.Should().BeTrue("internal transition was not executed.");
             stateContainer
-                .CurrentStateIdNew
+                .CurrentStateId
                 .Should()
                 .BeEquivalentTo(Initializable<States>.Initialized(States.A));
         }

--- a/source/Appccelerate.StateMachine.Specs/Async/AsyncActiveStateMachines.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/AsyncActiveStateMachines.cs
@@ -32,6 +32,7 @@ namespace Appccelerate.StateMachine.Specs.Async
         {
             "establish an instantiated active state machine".x(()
                 => machine = new StateMachineDefinitionBuilder<string, int>()
+                    .WithInitialState("initial")
                     .Build()
                     .CreateActiveStateMachine());
 
@@ -55,6 +56,7 @@ namespace Appccelerate.StateMachine.Specs.Async
 
             "establish an instantiated active state machine with custom name".x(()
                 => machine = new StateMachineDefinitionBuilder<string, int>()
+                    .WithInitialState("initial")
                     .Build()
                     .CreateActiveStateMachine(name));
 
@@ -86,10 +88,9 @@ namespace Appccelerate.StateMachine.Specs.Async
                 stateMachineDefinitionBuilder.In("B").On(secondEvent).Goto("C");
                 stateMachineDefinitionBuilder.In("C").ExecuteOnEntry(() => signal.Set());
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState("A")
                     .Build()
                     .CreateActiveStateMachine();
-
-                machine.Initialize("A");
             });
 
             "when firing an event onto the state machine".x(async () =>
@@ -123,10 +124,9 @@ namespace Appccelerate.StateMachine.Specs.Async
                 stateMachineDefinitionBuilder.In("B").On(firstEvent).Goto("C");
                 stateMachineDefinitionBuilder.In("C").ExecuteOnEntry(() => signal.Set());
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState("A")
                     .Build()
                     .CreateActiveStateMachine();
-
-                machine.Initialize("A");
             });
 
             "when firing a priority event onto the state machine".x(async () =>
@@ -171,10 +171,9 @@ namespace Appccelerate.StateMachine.Specs.Async
                     .In("D")
                     .ExecuteOnEntry(() => signal.Set());
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState("A")
                     .Build()
                     .CreateActiveStateMachine();
-
-                machine.Initialize("A");
             });
 
             "when firing a priority event onto the state machine".x(async () =>

--- a/source/Appccelerate.StateMachine.Specs/Async/AsyncPassiveStateMachines.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/AsyncPassiveStateMachines.cs
@@ -31,6 +31,7 @@ namespace Appccelerate.StateMachine.Specs.Async
         {
             "establish an instantiated passive state machine".x(()
                 => machine = new StateMachineDefinitionBuilder<string, int>()
+                    .WithInitialState("initial")
                     .Build()
                     .CreatePassiveStateMachine());
 
@@ -54,6 +55,7 @@ namespace Appccelerate.StateMachine.Specs.Async
 
             "establish an instantiated passive state machine with custom name".x(()
                 => machine = new StateMachineDefinitionBuilder<string, int>()
+                    .WithInitialState("initial")
                     .Build()
                     .CreatePassiveStateMachine(name));
 
@@ -84,10 +86,9 @@ namespace Appccelerate.StateMachine.Specs.Async
                 stateMachineDefinitionBuilder.In("B").On(SecondEvent).Goto("C");
                 stateMachineDefinitionBuilder.In("C").ExecuteOnEntry(() => arrived = true);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState("A")
                     .Build()
                     .CreatePassiveStateMachine();
-
-                machine.Initialize("A");
             });
 
             "when firing an event onto the state machine".x(() =>
@@ -117,10 +118,9 @@ namespace Appccelerate.StateMachine.Specs.Async
                 stateMachineDefinitionBuilder.In("B").On(FirstEvent).Goto("C");
                 stateMachineDefinitionBuilder.In("C").ExecuteOnEntry(() => arrived = true);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState("A")
                     .Build()
                     .CreatePassiveStateMachine();
-
-                machine.Initialize("A");
             });
 
             "when firing a priority event onto the state machine".x(() =>

--- a/source/Appccelerate.StateMachine.Specs/Async/CustomTypes.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/CustomTypes.cs
@@ -43,10 +43,9 @@ namespace Appccelerate.StateMachine.Specs.Async
                         .ExecuteOnEntry(() => arrivedInStateB = true);
 
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(new MyState("A"))
                     .Build()
                     .CreatePassiveStateMachine();
-
-                await machine.Initialize(new MyState("A"));
 
                 await machine.Start();
             });

--- a/source/Appccelerate.StateMachine.Specs/Async/EntryActions.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/EntryActions.cs
@@ -48,15 +48,13 @@ namespace Appccelerate.StateMachine.Specs.Async
                         });
 
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when entering the state".x(async () =>
-            {
-                await machine.Initialize(State);
-                await machine.Start();
-            });
+                await machine.Start());
 
             "it should execute the synchronous entry action".x(()
                 => entryActionExecuted.Should().BeTrue());
@@ -87,15 +85,13 @@ namespace Appccelerate.StateMachine.Specs.Async
                             },
                             parameter);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when entering the state".x(async () =>
-            {
-                await machine.Initialize(State);
-                await machine.Start();
-            });
+                await machine.Start());
 
             "it should execute the entry synchronous action".x(()
                 => receivedParameter.Should().NotBeNull());
@@ -136,15 +132,13 @@ namespace Appccelerate.StateMachine.Specs.Async
                             await Task.Yield();
                         });
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when entering the state".x(async () =>
-            {
-                await machine.Initialize(State);
-                await machine.Start();
-            });
+                await machine.Start());
 
             "it should execute all entry actions".x(()
                 => new[]
@@ -192,6 +186,7 @@ namespace Appccelerate.StateMachine.Specs.Async
                             throw exception4;
                         });
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
 
@@ -199,10 +194,7 @@ namespace Appccelerate.StateMachine.Specs.Async
             });
 
             "when entering the state".x(async () =>
-            {
-                await machine.Initialize(State);
-                await machine.Start();
-            });
+                await machine.Start());
 
             "it should execute all entry actions on entry".x(()
                 => new[]
@@ -246,13 +238,13 @@ namespace Appccelerate.StateMachine.Specs.Async
                         });
 
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when entering the state".x(async () =>
             {
-                await machine.Initialize(State);
                 await machine.Start();
                 await machine.Fire(Event, argument);
             });

--- a/source/Appccelerate.StateMachine.Specs/Async/ExceptionHandling.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/ExceptionHandling.cs
@@ -42,6 +42,7 @@ namespace Appccelerate.StateMachine.Specs.Async
                         .Goto(Values.Destination)
                         .Execute(() => throw Values.Exception);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(Values.Source)
                     .Build()
                     .CreatePassiveStateMachine();
 
@@ -50,7 +51,6 @@ namespace Appccelerate.StateMachine.Specs.Async
 
             "when executing the transition".x(async () =>
             {
-                await machine.Initialize(Values.Source);
                 await machine.Start();
                 await machine.Fire(Values.Event, Values.Parameter);
             });
@@ -72,6 +72,7 @@ namespace Appccelerate.StateMachine.Specs.Async
                     .In(Values.Destination)
                     .ExecuteOnEntry(() => throw Values.Exception);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(Values.Source)
                     .Build()
                     .CreatePassiveStateMachine();
 
@@ -80,7 +81,6 @@ namespace Appccelerate.StateMachine.Specs.Async
 
             "when executing the transition".x(async () =>
             {
-                await machine.Initialize(Values.Source);
                 await machine.Start();
                 await machine.Fire(Values.Event, Values.Parameter);
             });
@@ -99,6 +99,7 @@ namespace Appccelerate.StateMachine.Specs.Async
                         .ExecuteOnExit(() => throw Values.Exception)
                         .On(Values.Event).Goto(Values.Destination);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(Values.Source)
                     .Build()
                     .CreatePassiveStateMachine();
 
@@ -107,7 +108,6 @@ namespace Appccelerate.StateMachine.Specs.Async
 
             "when executing the transition".x(async () =>
             {
-                await machine.Initialize(Values.Source);
                 await machine.Start();
                 await machine.Fire(Values.Event, Values.Parameter);
             });
@@ -127,6 +127,7 @@ namespace Appccelerate.StateMachine.Specs.Async
                             .If((Func<Task<bool>>)(() => throw Values.Exception))
                             .Goto(Values.Destination);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(Values.Source)
                     .Build()
                     .CreatePassiveStateMachine();
 
@@ -135,7 +136,6 @@ namespace Appccelerate.StateMachine.Specs.Async
 
             "when executing the transition".x(async () =>
             {
-                await machine.Initialize(Values.Source);
                 await machine.Start();
                 await machine.Fire(Values.Event, Values.Parameter);
             });
@@ -144,7 +144,7 @@ namespace Appccelerate.StateMachine.Specs.Async
         }
 
         [Scenario]
-        public void InitializationException(AsyncPassiveStateMachine<int, int> machine)
+        public void StartingException(AsyncPassiveStateMachine<int, int> machine)
         {
             const int state = 1;
 
@@ -155,15 +155,15 @@ namespace Appccelerate.StateMachine.Specs.Async
                     .In(state)
                     .ExecuteOnEntry(() => throw Values.Exception);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(Values.Source)
                     .Build()
                     .CreatePassiveStateMachine();
 
                 machine.TransitionExceptionThrown += (s, e) => this.receivedTransitionExceptionEventArgs = e;
             });
 
-            "when initializing the state machine".x(async () =>
+            "when starting the state machine".x(async () =>
             {
-                await machine.Initialize(state);
                 await machine.Start();
             });
 
@@ -186,10 +186,10 @@ namespace Appccelerate.StateMachine.Specs.Async
                     .In(Values.Source)
                         .On(Values.Event).Execute(() => throw Values.Exception);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(Values.Source)
                     .Build()
                     .CreatePassiveStateMachine();
 
-                await machine.Initialize(Values.Source);
                 await machine.Start();
             });
 

--- a/source/Appccelerate.StateMachine.Specs/Async/ExitActions.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/ExitActions.cs
@@ -50,13 +50,13 @@ namespace Appccelerate.StateMachine.Specs.Async
                         })
                         .On(Event).Goto(AnotherState);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when leaving the state".x(async () =>
             {
-                await machine.Initialize(State);
                 await machine.Start();
                 await machine.Fire(Event);
             });
@@ -91,13 +91,13 @@ namespace Appccelerate.StateMachine.Specs.Async
                             parameter)
                         .On(Event).Goto(AnotherState);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when leaving the state".x(async () =>
             {
-                await machine.Initialize(State);
                 await machine.Start();
                 await machine.Fire(Event);
             });
@@ -142,13 +142,13 @@ namespace Appccelerate.StateMachine.Specs.Async
                         })
                         .On(Event).Goto(AnotherState);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when leaving the state".x(async () =>
             {
-                await machine.Initialize(State);
                 await machine.Start();
                 await machine.Fire(Event);
             });
@@ -201,6 +201,7 @@ namespace Appccelerate.StateMachine.Specs.Async
                         .On(Event).Goto(AnotherState);
 
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
 
@@ -209,7 +210,6 @@ namespace Appccelerate.StateMachine.Specs.Async
 
             "when entering the state".x(async () =>
             {
-                await machine.Initialize(State);
                 await machine.Start();
                 await machine.Fire(Event);
             });
@@ -248,13 +248,13 @@ namespace Appccelerate.StateMachine.Specs.Async
                         .ExecuteOnEntry((int a) => passedArgument = a);
 
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when leaving the state".x(async () =>
             {
-                await machine.Initialize(State);
                 await machine.Start();
                 await machine.Fire(Event, argument);
             });

--- a/source/Appccelerate.StateMachine.Specs/Async/Extensions.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/Extensions.cs
@@ -46,7 +46,6 @@ namespace Appccelerate.StateMachine.Specs.Async
 
                 machine.AddExtension(extension);
 
-                await machine.Initialize("0");
                 await machine.Start();
             });
 
@@ -55,7 +54,7 @@ namespace Appccelerate.StateMachine.Specs.Async
 
             "it should call EnteringState on registered extensions for target state".x(()
                 => A.CallTo(() => extension.EnteringState(
-                        A<IStateMachineInformation<string, int>>.That.Matches(x => x.Name == Name && x.CurrentStateId == "1"),
+                        A<IStateMachineInformation<string, int>>.That.Matches(x => x.Name == Name && x.CurrentStateId.ExtractOrThrow() == "1"),
                         A<IStateDefinition<string, int>>.That.Matches(x => x.Id == "1"),
                         A<ITransitionContext<string, int>>.That.Matches(x => x.EventId.Value == 1)))
                     .MustHaveHappened());
@@ -86,7 +85,6 @@ namespace Appccelerate.StateMachine.Specs.Async
 
                 machine.AddExtension(extension);
 
-                await machine.Initialize("0");
                 await machine.Start();
             });
 
@@ -95,14 +93,14 @@ namespace Appccelerate.StateMachine.Specs.Async
 
             "it should call EnteringState on registered extensions for entered super states of target state".x(()
                 => A.CallTo(() => extension.EnteringState(
-                        A<IStateMachineInformation<string, string>>.That.Matches(x => x.Name == Name && x.CurrentStateId == "A0"),
+                        A<IStateMachineInformation<string, string>>.That.Matches(x => x.Name == Name && x.CurrentStateId.ExtractOrThrow() == "A0"),
                         A<IStateDefinition<string, string>>.That.Matches(x => x.Id == "A"),
                         A<ITransitionContext<string, string>>.That.Matches(x => x.EventId.Value == "A0")))
                     .MustHaveHappened());
 
             "it should call EnteringState on registered extensions for entered leaf target state".x(()
                 => A.CallTo(() => extension.EnteringState(
-                        A<IStateMachineInformation<string, string>>.That.Matches(x => x.Name == Name && x.CurrentStateId == "A0"),
+                        A<IStateMachineInformation<string, string>>.That.Matches(x => x.Name == Name && x.CurrentStateId.ExtractOrThrow() == "A0"),
                         A<IStateDefinition<string, string>>.That.Matches(x => x.Id == "A0"),
                         A<ITransitionContext<string, string>>.That.Matches(x => x.EventId.Value == "A0")))
                     .MustHaveHappened());

--- a/source/Appccelerate.StateMachine.Specs/Async/Extensions.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/Extensions.cs
@@ -41,6 +41,7 @@ namespace Appccelerate.StateMachine.Specs.Async
                         .On(1)
                         .Goto("1");
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState("0")
                     .Build()
                     .CreatePassiveStateMachine(Name);
 
@@ -80,6 +81,7 @@ namespace Appccelerate.StateMachine.Specs.Async
                         .On("A0")
                         .Goto("A0");
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState("0")
                     .Build()
                     .CreatePassiveStateMachine(Name);
 

--- a/source/Appccelerate.StateMachine.Specs/Async/Guards.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/Guards.cs
@@ -48,13 +48,13 @@ namespace Appccelerate.StateMachine.Specs.Async
                             .If(() => true).Goto(ErrorState)
                             .Otherwise().Goto(ErrorState);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(SourceState)
                     .Build()
                     .CreatePassiveStateMachine();
 
                 currentStateExtension = new CurrentStateExtension();
                 machine.AddExtension(currentStateExtension);
 
-                await machine.Initialize(SourceState);
                 await machine.Start();
             });
 
@@ -79,6 +79,7 @@ namespace Appccelerate.StateMachine.Specs.Async
                         .On(Event)
                         .If(() => Task.FromResult(false)).Goto(ErrorState);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(SourceState)
                     .Build()
                     .CreatePassiveStateMachine();
 
@@ -86,7 +87,6 @@ namespace Appccelerate.StateMachine.Specs.Async
                 machine.AddExtension(currentStateExtension);
                 machine.TransitionDeclined += (sender, e) => declined = true;
 
-                await machine.Initialize(SourceState);
                 await machine.Start();
             });
 
@@ -111,13 +111,13 @@ namespace Appccelerate.StateMachine.Specs.Async
                             .If(() => Task.FromResult(false)).Goto(ErrorState)
                             .Otherwise().Goto(DestinationState);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(SourceState)
                     .Build()
                     .CreatePassiveStateMachine();
 
                 currentStateExtension = new CurrentStateExtension();
                 machine.AddExtension(currentStateExtension);
 
-                await machine.Initialize(SourceState);
                 await machine.Start();
             });
 

--- a/source/Appccelerate.StateMachine.Specs/Async/HierarchicalTransitions.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/HierarchicalTransitions.cs
@@ -95,10 +95,10 @@ namespace Appccelerate.StateMachine.Specs.Async
                         .ExecuteOnEntry(() => log += "enter" + grandParentOfDestinationState);
 
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(sourceState)
                     .Build()
                     .CreatePassiveStateMachine();
 
-                await machine.Initialize(sourceState);
                 await machine.Start();
             });
 
@@ -186,10 +186,10 @@ namespace Appccelerate.StateMachine.Specs.Async
                         .ExecuteOnExit(() => commonAncestorStateLeft = true);
 
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(sourceState)
                     .Build()
                     .CreatePassiveStateMachine();
 
-                await machine.Initialize(sourceState);
                 await machine.Start();
             });
 

--- a/source/Appccelerate.StateMachine.Specs/Async/IncompleteConfiguration.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/IncompleteConfiguration.cs
@@ -34,22 +34,32 @@ namespace Appccelerate.StateMachine.Specs.Async
             "establish a StateDefinition without configurations".x(() =>
             {
                 machine = new StateMachineDefinitionBuilder<int, int>()
+                    .WithInitialState(state)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when the state machine is started".x(async () =>
-            {
-                await machine.Initialize(state);
-                receivedException = await Catch.Exception(async () =>
-                    await machine.Start());
-            });
+                receivedException = await Catch.Exception(async () => await machine.Start()));
 
             "it should throw an exception, indicating the missing configuration".x(() =>
                 receivedException
                     .Message
                     .Should()
                     .Be($"Cannot find StateDefinition for state {state}. Are you sure you have configured this state via myStateDefinitionBuilder.In(..) or myStateDefinitionBuilder.DefineHierarchyOn(..)?"));
+        }
+
+        [Scenario]
+        public void BuildingAStateMachineWithoutInitialStateThenInvalidOperationException()
+        {
+            var testee = new StateMachineDefinitionBuilder<int, int>();
+
+            Action action = () => testee.Build();
+
+            action
+                .Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("Initial state is not configured.");
         }
     }
 }

--- a/source/Appccelerate.StateMachine.Specs/Async/Initialization.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/Initialization.cs
@@ -18,164 +18,43 @@
 
 namespace Appccelerate.StateMachine.Specs.Async
 {
-    using System;
-    using System.Collections.Generic;
     using AsyncMachine;
     using FluentAssertions;
-    using Infrastructure;
-    using Specs;
     using Xbehave;
 
     public class Initialization
     {
         private const int TestState = 1;
 
-        private readonly CurrentStateExtension testExtension = new CurrentStateExtension();
-
         [Scenario]
         public void Start(
             AsyncPassiveStateMachine<int, int> machine,
-            bool entryActionExecuted)
+            bool entryActionExecuted,
+            CurrentStateExtension currentStateExtension)
         {
-            "establish an initialized state machine".x(async () =>
+            "establish an initialized state machine".x(() =>
             {
                 var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<int, int>();
                 stateMachineDefinitionBuilder
                     .In(TestState)
                         .ExecuteOnEntry(() => entryActionExecuted = true);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(TestState)
                     .Build()
                     .CreatePassiveStateMachine();
 
-                machine.AddExtension(this.testExtension);
-
-                await machine.Initialize(TestState);
+                currentStateExtension = new CurrentStateExtension();
+                machine.AddExtension(currentStateExtension);
             });
 
             "when starting the state machine".x(() =>
                 machine.Start());
 
             "should set current state of state machine to state to which it is initialized".x(() =>
-                this.testExtension.CurrentState.Should().Be(TestState));
+                currentStateExtension.CurrentState.Should().Be(TestState));
 
             "should execute entry action of state to which state machine is initialized".x(() =>
                 entryActionExecuted.Should().BeTrue());
-        }
-
-        [Scenario]
-        public void Initialize(
-            AsyncPassiveStateMachine<int, int> machine,
-            bool entryActionExecuted)
-        {
-            "establish a state machine".x(() =>
-            {
-                var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<int, int>();
-                stateMachineDefinitionBuilder
-                    .In(TestState)
-                        .ExecuteOnEntry(() => entryActionExecuted = true);
-                machine = stateMachineDefinitionBuilder
-                    .Build()
-                    .CreatePassiveStateMachine();
-
-                machine.AddExtension(this.testExtension);
-            });
-
-            "when state machine is initialized".x(async () =>
-                await machine.Initialize(TestState));
-
-            "should not yet execute any entry actions".x(() =>
-                entryActionExecuted.Should().BeFalse());
-        }
-
-        [Scenario]
-        public void Reinitialization(
-            AsyncPassiveStateMachine<int, int> machine,
-            Exception receivedException)
-        {
-            "establish an initialized state machine".x(async () =>
-            {
-                machine = new StateMachineDefinitionBuilder<int, int>()
-                    .Build()
-                    .CreatePassiveStateMachine();
-                await machine.Initialize(TestState);
-            });
-
-            "when state machine is initialized again".x(async () =>
-            {
-                try
-                {
-                    await machine.Initialize(TestState);
-                }
-                catch (Exception e)
-                {
-                    receivedException = e;
-                }
-            });
-
-            "should throw an invalid operation exception".x(() =>
-            {
-                receivedException
-                    .Should().BeAssignableTo<InvalidOperationException>();
-                receivedException.Message
-                    .Should().Be(ExceptionMessages.StateMachineIsAlreadyInitialized);
-            });
-        }
-
-        [Scenario]
-        public void StartingAnUninitializedStateMachine(
-            AsyncPassiveStateMachine<int, int> machine,
-            Exception receivedException)
-        {
-            "establish an uninitialized state machine".x(() =>
-                machine = new StateMachineDefinitionBuilder<int, int>()
-                    .Build()
-                    .CreatePassiveStateMachine());
-
-            "when starting the state machine".x(async () =>
-                receivedException = await Catch.Exception(async () => await machine.Start()));
-
-            "should throw an invalid operation exception".x(() =>
-            {
-                receivedException
-                    .Should().BeAssignableTo<InvalidOperationException>();
-                receivedException.Message
-                    .Should().Be(ExceptionMessages.StateMachineNotInitialized);
-            });
-        }
-
-        [Scenario]
-        public void InitializeALoadedStateMachine(
-            AsyncPassiveStateMachine<int, int> machine,
-            Exception receivedException)
-        {
-            "establish a loaded initialized state machine".x(async () =>
-            {
-                var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<int, int>();
-                stateMachineDefinitionBuilder
-                    .In(1);
-                machine = stateMachineDefinitionBuilder
-                    .Build()
-                    .CreatePassiveStateMachine();
-
-                var loader = new Persisting.StateMachineLoader<int>();
-
-                loader.SetCurrentState(new Initializable<int> { Value = 1 });
-                loader.SetHistoryStates(new Dictionary<int, int>());
-
-                await machine.Load(loader);
-            });
-
-            "when initializing the state machine".x(async () =>
-                    receivedException = await Catch.Exception(async () =>
-                        await machine.Initialize(0)));
-
-            "should throw an invalid operation exception".x(() =>
-            {
-                receivedException
-                    .Should().BeAssignableTo<InvalidOperationException>();
-                receivedException.Message
-                    .Should().Be(ExceptionMessages.StateMachineIsAlreadyInitialized);
-            });
         }
     }
 }

--- a/source/Appccelerate.StateMachine.Specs/Async/Persisting.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/Persisting.cs
@@ -188,7 +188,7 @@ namespace Appccelerate.StateMachine.Specs.Async
 
             public override void Loaded(
                 IStateMachineInformation<State, Event> stateMachineInformation,
-                Initializable<State> loadedCurrentState,
+                IInitializable<State> loadedCurrentState,
                 IReadOnlyDictionary<State, State> loadedHistoryStates)
             {
                 this.LoadedCurrentState.Add(loadedCurrentState.Value);
@@ -198,11 +198,11 @@ namespace Appccelerate.StateMachine.Specs.Async
         public class StateMachineSaver<TState> : IAsyncStateMachineSaver<TState>
             where TState : IComparable
         {
-            public Initializable<TState> CurrentStateId { get; private set; }
+            public IInitializable<TState> CurrentStateId { get; private set; }
 
             public IReadOnlyDictionary<TState, TState> HistoryStates { get; private set; }
 
-            public Task SaveCurrentState(Initializable<TState> currentState)
+            public Task SaveCurrentState(IInitializable<TState> currentState)
             {
                 this.CurrentStateId = currentState;
 
@@ -220,10 +220,10 @@ namespace Appccelerate.StateMachine.Specs.Async
         public class StateMachineLoader<TState> : IAsyncStateMachineLoader<TState>
             where TState : IComparable
         {
-            private Initializable<TState> currentState;
+            private IInitializable<TState> currentState;
             private IReadOnlyDictionary<TState, TState> historyStates;
 
-            public void SetCurrentState(Initializable<TState> state)
+            public void SetCurrentState(IInitializable<TState> state)
             {
                 this.currentState = state;
             }
@@ -238,7 +238,7 @@ namespace Appccelerate.StateMachine.Specs.Async
                 return Task.FromResult(this.historyStates);
             }
 
-            public Task<Initializable<TState>> LoadCurrentState()
+            public Task<IInitializable<TState>> LoadCurrentState()
             {
                 return Task.FromResult(this.currentState);
             }

--- a/source/Appccelerate.StateMachine.Specs/Async/Reporting.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/Reporting.cs
@@ -33,6 +33,7 @@ namespace Appccelerate.StateMachine.Specs.Async
         {
             "establish a state machine".x(()
                 => machine = new StateMachineDefinitionBuilder<string, int>()
+                    .WithInitialState("initial")
                     .Build()
                     .CreatePassiveStateMachine());
 

--- a/source/Appccelerate.StateMachine.Specs/Async/Reporting.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/Reporting.cs
@@ -22,7 +22,6 @@ namespace Appccelerate.StateMachine.Specs.Async
     using AsyncMachine;
     using AsyncMachine.States;
     using FakeItEasy;
-    using Infrastructure;
     using Xbehave;
 
     public class Reporting
@@ -45,7 +44,7 @@ namespace Appccelerate.StateMachine.Specs.Async
 
             "it should call the passed reporter".x(()
                 => A.CallTo(() =>
-                        report.Report(A<string>._, A<IEnumerable<IStateDefinition<string, int>>>._, A<Initializable<string>>._))
+                        report.Report(A<string>._, A<IEnumerable<IStateDefinition<string, int>>>._, A<string>._))
                     .MustHaveHappened());
         }
     }

--- a/source/Appccelerate.StateMachine.Specs/Async/StartStop.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/StartStop.cs
@@ -34,7 +34,7 @@ namespace Appccelerate.StateMachine.Specs.Async
         [Background]
         public void Background()
         {
-            "establish initialized state machine".x(() =>
+            "establish a state machine".x(() =>
             {
                 var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<int, int>();
                 stateMachineDefinitionBuilder
@@ -44,13 +44,12 @@ namespace Appccelerate.StateMachine.Specs.Async
                     .In(B)
                         .On(Event).Goto(A);
                 this.machine = stateMachineDefinitionBuilder
+                    .WithInitialState(A)
                     .Build()
                     .CreatePassiveStateMachine();
 
                 this.extension = new RecordEventsExtension();
                 this.machine.AddExtension(this.extension);
-
-                this.machine.Initialize(A);
             });
         }
 

--- a/source/Appccelerate.StateMachine.Specs/Async/StateMachineNameReporter.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/StateMachineNameReporter.cs
@@ -21,13 +21,12 @@ namespace Appccelerate.StateMachine.Specs.Async
     using System.Collections.Generic;
     using AsyncMachine;
     using AsyncMachine.States;
-    using Infrastructure;
 
     public class StateMachineNameReporter : IStateMachineReport<string, int>
     {
         public string StateMachineName { get; private set; }
 
-        public void Report(string name, IEnumerable<IStateDefinition<string, int>> states, Initializable<string> initialStateId)
+        public void Report(string name, IEnumerable<IStateDefinition<string, int>> states, string initialStateId)
         {
             this.StateMachineName = name;
         }

--- a/source/Appccelerate.StateMachine.Specs/Async/Transitions.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/Transitions.cs
@@ -72,12 +72,12 @@ namespace Appccelerate.StateMachine.Specs.Async
                         });
 
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(SourceState)
                     .Build()
                     .CreatePassiveStateMachine();
 
                 machine.AddExtension(CurrentStateExtension);
 
-                await machine.Initialize(SourceState);
                 await machine.Start();
             });
 

--- a/source/Appccelerate.StateMachine.Specs/Sync/ActiveStateMachines.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/ActiveStateMachines.cs
@@ -32,6 +32,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
         {
             "establish an instantiated active state machine".x(() =>
                 machine = new StateMachineDefinitionBuilder<string, int>()
+                    .WithInitialState("initial")
                     .Build()
                     .CreateActiveStateMachine());
 
@@ -57,6 +58,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
 
             "establish an instantiated active state machine with custom name".x(() =>
                 machine = new StateMachineDefinitionBuilder<string, int>()
+                    .WithInitialState("initial")
                     .Build()
                     .CreateActiveStateMachine(Name));
 
@@ -90,10 +92,9 @@ namespace Appccelerate.StateMachine.Specs.Sync
                 stateMachineDefinitionBuilder.In("B").On(SecondEvent).Goto("C");
                 stateMachineDefinitionBuilder.In("C").ExecuteOnEntry(() => signal.Set());
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState("A")
                     .Build()
                     .CreateActiveStateMachine();
-
-                machine.Initialize("A");
             });
 
             "when firing an event onto the state machine".x(() =>
@@ -127,10 +128,9 @@ namespace Appccelerate.StateMachine.Specs.Sync
                 stateMachineDefinitionBuilder.In("B").On(FirstEvent).Goto("C");
                 stateMachineDefinitionBuilder.In("C").ExecuteOnEntry(() => signal.Set());
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState("A")
                     .Build()
                     .CreateActiveStateMachine();
-
-                machine.Initialize("A");
             });
 
             "when firing a priority event onto the state machine".x(() =>

--- a/source/Appccelerate.StateMachine.Specs/Sync/CustomTypes.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/CustomTypes.cs
@@ -42,10 +42,9 @@ namespace Appccelerate.StateMachine.Specs.Sync
                     .In(new MyState("B"))
                         .ExecuteOnEntry(() => arrivedInStateB = true);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(new MyState("A"))
                     .Build()
                     .CreatePassiveStateMachine();
-
-                machine.Initialize(new MyState("A"));
 
                 machine.Start();
             });

--- a/source/Appccelerate.StateMachine.Specs/Sync/EntryActions.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/EntryActions.cs
@@ -40,13 +40,13 @@ namespace Appccelerate.StateMachine.Specs.Sync
                     .In(State)
                         .ExecuteOnEntry(() => entryActionExecuted = true);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when entering the state".x(() =>
             {
-                machine.Initialize(State);
                 machine.Start();
             });
 
@@ -68,13 +68,13 @@ namespace Appccelerate.StateMachine.Specs.Sync
                     .In(State)
                         .ExecuteOnEntryParametrized(p => parameter = p, Parameter);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when entering the state".x(() =>
             {
-                machine.Initialize(State);
                 machine.Start();
             });
 
@@ -99,13 +99,13 @@ namespace Appccelerate.StateMachine.Specs.Sync
                         .ExecuteOnEntry(() => entryAction1Executed = true)
                         .ExecuteOnEntry(() => entryAction2Executed = true);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when entering the state".x(() =>
             {
-                machine.Initialize(State);
                 machine.Start();
             });
 
@@ -147,6 +147,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
                             throw exception3;
                         });
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
 
@@ -155,7 +156,6 @@ namespace Appccelerate.StateMachine.Specs.Sync
 
             "when entering the state".x(() =>
             {
-                machine.Initialize(State);
                 machine.Start();
             });
 
@@ -200,13 +200,13 @@ namespace Appccelerate.StateMachine.Specs.Sync
                     .In(AnotherState)
                         .ExecuteOnEntry((int argument) => passedArgument = argument);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when entering the state".x(() =>
             {
-                machine.Initialize(State);
                 machine.Start();
                 machine.Fire(Event, Argument);
             });

--- a/source/Appccelerate.StateMachine.Specs/Sync/ExceptionHandling.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/ExceptionHandling.cs
@@ -40,6 +40,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
                         .Goto(Values.Destination)
                         .Execute(() => throw Values.Exception);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(Values.Source)
                     .Build()
                     .CreatePassiveStateMachine();
 
@@ -48,7 +49,6 @@ namespace Appccelerate.StateMachine.Specs.Sync
 
             "when executing the transition".x(() =>
             {
-                machine.Initialize(Values.Source);
                 machine.Start();
                 machine.Fire(Values.Event, Values.Parameter);
             });
@@ -70,6 +70,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
                     .In(Values.Destination)
                         .ExecuteOnEntry(() => throw Values.Exception);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(Values.Source)
                     .Build()
                     .CreatePassiveStateMachine();
 
@@ -78,7 +79,6 @@ namespace Appccelerate.StateMachine.Specs.Sync
 
             "when executing the transition".x(() =>
             {
-                machine.Initialize(Values.Source);
                 machine.Start();
                 machine.Fire(Values.Event, Values.Parameter);
             });
@@ -98,6 +98,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
                         .On(Values.Event)
                         .Goto(Values.Destination);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(Values.Source)
                     .Build()
                     .CreatePassiveStateMachine();
 
@@ -106,7 +107,6 @@ namespace Appccelerate.StateMachine.Specs.Sync
 
             "when executing the transition".x(() =>
             {
-                machine.Initialize(Values.Source);
                 machine.Start();
                 machine.Fire(Values.Event, Values.Parameter);
             });
@@ -126,6 +126,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
                         .If(() => throw Values.Exception)
                         .Goto(Values.Destination);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(Values.Source)
                     .Build()
                     .CreatePassiveStateMachine();
 
@@ -134,7 +135,6 @@ namespace Appccelerate.StateMachine.Specs.Sync
 
             "when executing the transition".x(() =>
             {
-                machine.Initialize(Values.Source);
                 machine.Start();
                 machine.Fire(Values.Event, Values.Parameter);
             });
@@ -154,6 +154,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
                     .In(State)
                         .ExecuteOnEntry(() => throw Values.Exception);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
 
@@ -161,10 +162,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
             });
 
             "when initializing the state machine".x(() =>
-            {
-                machine.Initialize(State);
-                machine.Start();
-            });
+                machine.Start());
 
             "should catch exception and fire transition exception event".x(() =>
                 this.receivedTransitionExceptionEventArgs.Exception.Should().NotBeNull());
@@ -186,10 +184,9 @@ namespace Appccelerate.StateMachine.Specs.Sync
                         .On(Values.Event)
                         .Execute(() => throw Values.Exception);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(Values.Source)
                     .Build()
                     .CreatePassiveStateMachine();
-
-                machine.Initialize(Values.Source);
 
                 machine.Start();
             });

--- a/source/Appccelerate.StateMachine.Specs/Sync/ExceptionHandling.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/ExceptionHandling.cs
@@ -143,7 +143,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
         }
 
         [Scenario]
-        public void InitializationException(PassiveStateMachine<int, int> machine)
+        public void StartingException(PassiveStateMachine<int, int> machine)
         {
             const int State = 1;
 
@@ -161,7 +161,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
                 machine.TransitionExceptionThrown += (s, e) => this.receivedTransitionExceptionEventArgs = e;
             });
 
-            "when initializing the state machine".x(() =>
+            "when starting the state machine".x(() =>
                 machine.Start());
 
             "should catch exception and fire transition exception event".x(() =>

--- a/source/Appccelerate.StateMachine.Specs/Sync/ExitActions.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/ExitActions.cs
@@ -43,13 +43,13 @@ namespace Appccelerate.StateMachine.Specs.Sync
                         .ExecuteOnExit(() => exitActionExecuted = true)
                         .On(Event).Goto(AnotherState);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when leaving the state".x(() =>
             {
-                machine.Initialize(State);
                 machine.Start();
                 machine.Fire(Event);
             });
@@ -73,13 +73,13 @@ namespace Appccelerate.StateMachine.Specs.Sync
                         .ExecuteOnExitParametrized(p => parameter = p, Parameter)
                         .On(Event).Goto(AnotherState);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when leaving the state".x(() =>
             {
-                machine.Initialize(State);
                 machine.Start();
                 machine.Fire(Event);
             });
@@ -106,13 +106,13 @@ namespace Appccelerate.StateMachine.Specs.Sync
                         .ExecuteOnExit(() => exitAction2Executed = true)
                         .On(Event).Goto(AnotherState);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when leaving the state".x(() =>
             {
-                machine.Initialize(State);
                 machine.Start();
                 machine.Fire(Event);
             });
@@ -156,6 +156,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
                         })
                         .On(Event).Goto(AnotherState);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
 
@@ -164,7 +165,6 @@ namespace Appccelerate.StateMachine.Specs.Sync
 
             "when entering the state".x(() =>
             {
-                machine.Initialize(State);
                 machine.Start();
                 machine.Fire(Event);
             });
@@ -209,13 +209,13 @@ namespace Appccelerate.StateMachine.Specs.Sync
                     .In(AnotherState)
                         .ExecuteOnEntry((int argument) => passedArgument = argument);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(State)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when leaving the state".x(() =>
             {
-                machine.Initialize(State);
                 machine.Start();
                 machine.Fire(Event, Argument);
             });

--- a/source/Appccelerate.StateMachine.Specs/Sync/Extensions.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/Extensions.cs
@@ -41,12 +41,12 @@ namespace Appccelerate.StateMachine.Specs.Sync
                         .On(1)
                         .Goto("1");
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState("0")
                     .Build()
                     .CreatePassiveStateMachine(Name);
 
                 machine.AddExtension(extension);
 
-                machine.Initialize("0");
                 machine.Start();
             });
 
@@ -55,7 +55,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
 
             "it should call EnteringState on registered extensions for target state".x(()
                 => A.CallTo(() => extension.EnteringState(
-                        A<IStateMachineInformation<string, int>>.That.Matches(x => x.Name == Name && x.CurrentStateId == "1"),
+                        A<IStateMachineInformation<string, int>>.That.Matches(x => x.Name == Name && x.CurrentStateIdNew.IsInitialized && x.CurrentStateIdNew.Value == "1"),
                         A<IStateDefinition<string, int>>.That.Matches(x => x.Id == "1"),
                         A<ITransitionContext<string, int>>.That.Matches(x => x.EventId.Value == 1)))
                     .MustHaveHappened());
@@ -81,12 +81,12 @@ namespace Appccelerate.StateMachine.Specs.Sync
                         .On("A0")
                         .Goto("A0");
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState("0")
                     .Build()
                     .CreatePassiveStateMachine(Name);
 
                 machine.AddExtension(extension);
 
-                machine.Initialize("0");
                 machine.Start();
             });
 
@@ -95,14 +95,14 @@ namespace Appccelerate.StateMachine.Specs.Sync
 
             "it should call EnteringState on registered extensions for entered super states of target state".x(()
                 => A.CallTo(() => extension.EnteringState(
-                        A<IStateMachineInformation<string, string>>.That.Matches(x => x.Name == Name && x.CurrentStateId == "A0"),
+                        A<IStateMachineInformation<string, string>>.That.Matches(x => x.Name == Name && x.CurrentStateIdNew.IsInitialized && x.CurrentStateIdNew.Value == "A0"),
                         A<IStateDefinition<string, string>>.That.Matches(x => x.Id == "A"),
                         A<ITransitionContext<string, string>>.That.Matches(x => x.EventId.Value == "A0")))
                     .MustHaveHappened());
 
             "it should call EnteringState on registered extensions for entered leaf target state".x(()
                 => A.CallTo(() => extension.EnteringState(
-                        A<IStateMachineInformation<string, string>>.That.Matches(x => x.Name == Name && x.CurrentStateId == "A0"),
+                        A<IStateMachineInformation<string, string>>.That.Matches(x => x.Name == Name && x.CurrentStateIdNew.IsInitialized && x.CurrentStateIdNew.Value == "A0"),
                         A<IStateDefinition<string, string>>.That.Matches(x => x.Id == "A0"),
                         A<ITransitionContext<string, string>>.That.Matches(x => x.EventId.Value == "A0")))
                     .MustHaveHappened());

--- a/source/Appccelerate.StateMachine.Specs/Sync/Extensions.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/Extensions.cs
@@ -55,7 +55,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
 
             "it should call EnteringState on registered extensions for target state".x(()
                 => A.CallTo(() => extension.EnteringState(
-                        A<IStateMachineInformation<string, int>>.That.Matches(x => x.Name == Name && x.CurrentStateIdNew.IsInitialized && x.CurrentStateIdNew.Value == "1"),
+                        A<IStateMachineInformation<string, int>>.That.Matches(x => x.Name == Name && x.CurrentStateId.ExtractOrThrow() == "1"),
                         A<IStateDefinition<string, int>>.That.Matches(x => x.Id == "1"),
                         A<ITransitionContext<string, int>>.That.Matches(x => x.EventId.Value == 1)))
                     .MustHaveHappened());
@@ -95,14 +95,14 @@ namespace Appccelerate.StateMachine.Specs.Sync
 
             "it should call EnteringState on registered extensions for entered super states of target state".x(()
                 => A.CallTo(() => extension.EnteringState(
-                        A<IStateMachineInformation<string, string>>.That.Matches(x => x.Name == Name && x.CurrentStateIdNew.IsInitialized && x.CurrentStateIdNew.Value == "A0"),
+                        A<IStateMachineInformation<string, string>>.That.Matches(x => x.Name == Name && x.CurrentStateId.ExtractOrThrow() == "A0"),
                         A<IStateDefinition<string, string>>.That.Matches(x => x.Id == "A"),
                         A<ITransitionContext<string, string>>.That.Matches(x => x.EventId.Value == "A0")))
                     .MustHaveHappened());
 
             "it should call EnteringState on registered extensions for entered leaf target state".x(()
                 => A.CallTo(() => extension.EnteringState(
-                        A<IStateMachineInformation<string, string>>.That.Matches(x => x.Name == Name && x.CurrentStateIdNew.IsInitialized && x.CurrentStateIdNew.Value == "A0"),
+                        A<IStateMachineInformation<string, string>>.That.Matches(x => x.Name == Name && x.CurrentStateId.ExtractOrThrow() == "A0"),
                         A<IStateDefinition<string, string>>.That.Matches(x => x.Id == "A0"),
                         A<ITransitionContext<string, string>>.That.Matches(x => x.EventId.Value == "A0")))
                     .MustHaveHappened());

--- a/source/Appccelerate.StateMachine.Specs/Sync/Guards.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/Guards.cs
@@ -46,13 +46,13 @@ namespace Appccelerate.StateMachine.Specs.Sync
                         .If(() => true).Goto(ErrorState)
                         .Otherwise().Goto(ErrorState);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(SourceState)
                     .Build()
                     .CreatePassiveStateMachine();
 
                 currentStateExtension = new CurrentStateExtension();
                 machine.AddExtension(currentStateExtension);
 
-                machine.Initialize(SourceState);
                 machine.Start();
             });
 
@@ -77,13 +77,13 @@ namespace Appccelerate.StateMachine.Specs.Sync
                         .If(() => false).Goto(ErrorState)
                         .Otherwise().Goto(DestinationState);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(SourceState)
                     .Build()
                     .CreatePassiveStateMachine();
 
                 currentStateExtension = new CurrentStateExtension();
                 machine.AddExtension(currentStateExtension);
 
-                machine.Initialize(SourceState);
                 machine.Start();
             });
 
@@ -108,12 +108,12 @@ namespace Appccelerate.StateMachine.Specs.Sync
                         .On(Event)
                         .If(() => false).Goto(ErrorState);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(SourceState)
                     .Build()
                     .CreatePassiveStateMachine();
 
                 machine.TransitionDeclined += (sender, e) => declined = true;
 
-                machine.Initialize(SourceState);
                 machine.Start();
             });
 

--- a/source/Appccelerate.StateMachine.Specs/Sync/HierarchicalStateMachineInitialization.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/HierarchicalStateMachineInitialization.cs
@@ -27,77 +27,97 @@ namespace Appccelerate.StateMachine.Specs.Sync
         private const int LeafState = 1;
         private const int SuperState = 0;
 
-        private readonly CurrentStateExtension testExtension = new CurrentStateExtension();
-        private PassiveStateMachine<int, int> machine;
-
-        private bool entryActionOfLeafStateExecuted;
-        private bool entryActionOfSuperStateExecuted;
-
-        [Background]
-        public void Background()
+        [Scenario]
+        public void InitializationInLeafState(
+            PassiveStateMachine<int, int> machine,
+            CurrentStateExtension testExtension,
+            bool entryActionOfLeafStateExecuted,
+            bool entryActionOfSuperStateExecuted)
         {
-            "establish a hierarchical state machine".x(() =>
+            "establish a hierarchical state machine with leaf state as initial state".x(() =>
             {
                 var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<int, int>();
                 stateMachineDefinitionBuilder
                     .DefineHierarchyOn(SuperState)
-                        .WithHistoryType(HistoryType.None)
-                        .WithInitialSubState(LeafState);
+                    .WithHistoryType(HistoryType.None)
+                    .WithInitialSubState(LeafState);
                 stateMachineDefinitionBuilder
                     .In(SuperState)
-                        .ExecuteOnEntry(() => this.entryActionOfSuperStateExecuted = true);
+                    .ExecuteOnEntry(() => entryActionOfSuperStateExecuted = true);
                 stateMachineDefinitionBuilder
                     .In(LeafState)
-                        .ExecuteOnEntry(() => this.entryActionOfLeafStateExecuted = true);
-                this.machine = stateMachineDefinitionBuilder
+                    .ExecuteOnEntry(() => entryActionOfLeafStateExecuted = true);
+                machine = stateMachineDefinitionBuilder
+                    .WithInitialState(LeafState)
                     .Build()
                     .CreatePassiveStateMachine();
 
-                this.machine.AddExtension(this.testExtension);
+                testExtension = new CurrentStateExtension();
+                machine.AddExtension(testExtension);
             });
-        }
 
-        [Scenario]
-        public void InitializationInLeafState()
-        {
-            "when initializing to a leaf state and starting the state machine".x(() =>
+            "when starting the state machine".x(() =>
             {
-                this.machine.Initialize(LeafState);
-                this.machine.Start();
+                machine.Start();
             });
 
             "it should set current state of state machine to state to which it is initialized".x(() =>
-                this.testExtension.CurrentState
+                testExtension.CurrentState
                     .Should().Be(LeafState));
 
             "it should execute entry action of state to which state machine is initialized".x(() =>
-                this.entryActionOfLeafStateExecuted
+                entryActionOfLeafStateExecuted
                     .Should().BeTrue());
 
             "it should execute entry action of super states of the state to which state machine is initialized".x(() =>
-                this.entryActionOfSuperStateExecuted
+                entryActionOfSuperStateExecuted
                     .Should().BeTrue());
         }
 
         [Scenario]
-        public void InitializationInSuperState()
+        public void InitializationInSuperState(
+            PassiveStateMachine<int, int> machine,
+            CurrentStateExtension testExtension,
+            bool entryActionOfLeafStateExecuted,
+            bool entryActionOfSuperStateExecuted)
         {
+            "establish a hierarchical state machine with super state as initial state".x(() =>
+            {
+                var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<int, int>();
+                stateMachineDefinitionBuilder
+                    .DefineHierarchyOn(SuperState)
+                    .WithHistoryType(HistoryType.None)
+                    .WithInitialSubState(LeafState);
+                stateMachineDefinitionBuilder
+                    .In(SuperState)
+                    .ExecuteOnEntry(() => entryActionOfSuperStateExecuted = true);
+                stateMachineDefinitionBuilder
+                    .In(LeafState)
+                    .ExecuteOnEntry(() => entryActionOfLeafStateExecuted = true);
+                machine = stateMachineDefinitionBuilder
+                    .WithInitialState(SuperState)
+                    .Build()
+                    .CreatePassiveStateMachine();
+
+                testExtension = new CurrentStateExtension();
+                machine.AddExtension(testExtension);
+            });
+
             "when initializing to a super state and starting the state machine".x(() =>
             {
-                this.machine.Initialize(SuperState);
-                this.machine.Start();
+                machine.Start();
             });
 
             "it should_set_current_state_of_state_machine_to_initial_leaf_state_of_the_state_to_which_it_is_initialized".x(() =>
-                this.testExtension.CurrentState
+                testExtension.CurrentState
                     .Should().Be(LeafState));
 
             "it should_execute_entry_action_of_super_state_to_which_state_machine_is_initialized".x(() =>
-                this.entryActionOfSuperStateExecuted
+                entryActionOfSuperStateExecuted
                     .Should().BeTrue());
 
             "it should_execute_entry_actions_of_initial_sub_states_until_a_leaf_state_is_reached".x(() =>
-                this.entryActionOfLeafStateExecuted
+                entryActionOfLeafStateExecuted
                     .Should().BeTrue());
         }
     }

--- a/source/Appccelerate.StateMachine.Specs/Sync/HierarchicalTransitions.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/HierarchicalTransitions.cs
@@ -84,10 +84,10 @@ namespace Appccelerate.StateMachine.Specs.Sync
                     .In(GrandParentOfDestinationState)
                         .ExecuteOnEntry(() => log += "enter" + GrandParentOfDestinationState);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(SourceState)
                     .Build()
                     .CreatePassiveStateMachine();
 
-                machine.Initialize(SourceState);
                 machine.Start();
             });
 
@@ -169,10 +169,10 @@ namespace Appccelerate.StateMachine.Specs.Sync
                     .In(CommonAncestorState)
                         .ExecuteOnExit(() => commonAncestorStateLeft = true);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(SourceState)
                     .Build()
                     .CreatePassiveStateMachine();
 
-                machine.Initialize(SourceState);
                 machine.Start();
             });
 

--- a/source/Appccelerate.StateMachine.Specs/Sync/IncompleteConfiguration.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/IncompleteConfiguration.cs
@@ -40,9 +40,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
             });
 
             "when the state machine is started".x(() =>
-            {
-                receivedException = Catch.Exception(() => machine.Start());
-            });
+                receivedException = Catch.Exception(() => machine.Start()));
 
             "it should throw an exception, indicating the missing configuration".x(() =>
                 receivedException

--- a/source/Appccelerate.StateMachine.Specs/Sync/IncompleteConfiguration.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/IncompleteConfiguration.cs
@@ -31,16 +31,16 @@ namespace Appccelerate.StateMachine.Specs.Sync
             Exception receivedException,
             int state = 0)
         {
-            "establish a StateDefinition without configurations".x(() =>
+            "establish a StateDefinition without any state configurations".x(() =>
             {
                 machine = new StateMachineDefinitionBuilder<int, int>()
+                    .WithInitialState(state)
                     .Build()
                     .CreatePassiveStateMachine();
             });
 
             "when the state machine is started".x(() =>
             {
-                machine.Initialize(state);
                 receivedException = Catch.Exception(() => machine.Start());
             });
 
@@ -49,6 +49,19 @@ namespace Appccelerate.StateMachine.Specs.Sync
                     .Message
                     .Should()
                     .Be($"Cannot find StateDefinition for state {state}. Are you sure you have configured this state via myStateDefinitionBuilder.In(..) or myStateDefinitionBuilder.DefineHierarchyOn(..)?"));
+        }
+
+        [Scenario]
+        public void BuildingAStateMachineWithoutInitialStateThenInvalidOperationException()
+        {
+            var testee = new StateMachineDefinitionBuilder<int, int>();
+
+            Action action = () => testee.Build();
+
+            action
+                .Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("Initial state is not configured.");
         }
     }
 }

--- a/source/Appccelerate.StateMachine.Specs/Sync/Initialization.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/Initialization.cs
@@ -18,12 +18,8 @@
 
 namespace Appccelerate.StateMachine.Specs.Sync
 {
-    using System;
-    using System.Collections.Generic;
     using FluentAssertions;
-    using Infrastructure;
     using Machine;
-    using Specs;
     using Xbehave;
 
     public class Initialization
@@ -36,20 +32,19 @@ namespace Appccelerate.StateMachine.Specs.Sync
             bool entryActionExecuted,
             CurrentStateExtension currentStateExtension)
         {
-            "establish an initialized state machine".x(() =>
+            "establish a state machine".x(() =>
             {
                 var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<int, int>();
                 stateMachineDefinitionBuilder
                     .In(TestState)
                         .ExecuteOnEntry(() => entryActionExecuted = true);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(TestState)
                     .Build()
                     .CreatePassiveStateMachine();
 
                 currentStateExtension = new CurrentStateExtension();
                 machine.AddExtension(currentStateExtension);
-
-                machine.Initialize(TestState);
             });
 
             "when starting the state machine".x(() =>
@@ -60,106 +55,6 @@ namespace Appccelerate.StateMachine.Specs.Sync
 
             "should execute entry action of state to which state machine is initialized".x(() =>
                 entryActionExecuted.Should().BeTrue());
-        }
-
-        [Scenario]
-        public void Initialize(
-            PassiveStateMachine<int, int> machine,
-            bool entryActionExecuted)
-        {
-            "establish a state machine".x(() =>
-            {
-                var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<int, int>();
-                stateMachineDefinitionBuilder
-                    .In(TestState)
-                    .ExecuteOnEntry(() => entryActionExecuted = true);
-                machine = stateMachineDefinitionBuilder
-                    .Build()
-                    .CreatePassiveStateMachine();
-            });
-
-            "when state machine is initialized".x(() =>
-                machine.Initialize(TestState));
-
-            "should not yet execute any entry actions".x(() =>
-                entryActionExecuted.Should().BeFalse());
-        }
-
-        [Scenario]
-        public void Reinitialization(
-            PassiveStateMachine<int, int> machine,
-            Exception receivedException)
-        {
-            "establish an initialized state machine".x(() =>
-            {
-                machine = new StateMachineDefinitionBuilder<int, int>()
-                    .Build()
-                    .CreatePassiveStateMachine();
-                machine.Initialize(TestState);
-            });
-
-            "when state machine is initialized again".x(() =>
-                receivedException = Catch.Exception(() =>
-                    machine.Initialize(TestState)));
-
-            "should throw an invalid operation exception".x(() =>
-                receivedException
-                    .Should().BeAssignableTo<InvalidOperationException>()
-                    .Which.Message
-                    .Should().Be(ExceptionMessages.StateMachineIsAlreadyInitialized));
-        }
-
-        [Scenario]
-        public void StartingAnUninitializedStateMachine(
-            PassiveStateMachine<int, int> machine,
-            Exception receivedException)
-        {
-            "establish an uninitialized state machine".x(() =>
-                machine = new StateMachineDefinitionBuilder<int, int>()
-                    .Build()
-                    .CreatePassiveStateMachine());
-
-            "when starting the state machine".x(() =>
-                receivedException = Catch.Exception(() =>
-                    machine.Start()));
-
-            "should throw an invalid operation exception".x(() =>
-                receivedException
-                    .Should().BeAssignableTo<InvalidOperationException>()
-                    .Which.Message
-                    .Should().Be(ExceptionMessages.StateMachineNotInitialized));
-        }
-
-        [Scenario]
-        public void InitializeALoadedStateMachine(
-            PassiveStateMachine<int, int> machine,
-            Exception receivedException,
-            CurrentStateExtension currentStateExtension)
-        {
-            "establish a loaded initialized state machine".x(() =>
-            {
-                var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<int, int>();
-                stateMachineDefinitionBuilder
-                    .In(1);
-                machine = stateMachineDefinitionBuilder
-                    .Build()
-                    .CreatePassiveStateMachine();
-
-                var loader = new Persisting.StateMachineLoader<int>();
-                loader.SetCurrentState(new Initializable<int> { Value = 1 });
-                loader.SetHistoryStates(new Dictionary<int, int>());
-                machine.Load(loader);
-            });
-
-            "when initializing the state machine".x(() =>
-                receivedException = Catch.Exception(() =>
-                    machine.Initialize(0)));
-
-            "should throw an invalid operation exception".x(() =>
-                receivedException
-                    .Should().BeAssignableTo<InvalidOperationException>()
-                    .Which.Message
-                    .Should().Be(ExceptionMessages.StateMachineIsAlreadyInitialized));
         }
     }
 }

--- a/source/Appccelerate.StateMachine.Specs/Sync/PassiveStateMachines.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/PassiveStateMachines.cs
@@ -31,6 +31,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
         {
             "establish an instantiated passive state machine".x(() =>
                 machine = new StateMachineDefinitionBuilder<string, int>()
+                    .WithInitialState("initial")
                     .Build()
                     .CreatePassiveStateMachine());
 
@@ -56,6 +57,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
 
             "establish an instantiated passive state machine with custom name".x(() =>
                 machine = new StateMachineDefinitionBuilder<string, int>()
+                    .WithInitialState("initial")
                     .Build()
                     .CreatePassiveStateMachine(Name));
 
@@ -88,10 +90,9 @@ namespace Appccelerate.StateMachine.Specs.Sync
                 stateMachineDefinitionBuilder.In("B").On(SecondEvent).Goto("C");
                 stateMachineDefinitionBuilder.In("C").ExecuteOnEntry(() => arrived = true);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState("A")
                     .Build()
                     .CreatePassiveStateMachine();
-
-                machine.Initialize("A");
             });
 
             "when firing an event onto the state machine".x(() =>
@@ -123,10 +124,9 @@ namespace Appccelerate.StateMachine.Specs.Sync
                 stateMachineDefinitionBuilder.In("B").On(FirstEvent).Goto("C");
                 stateMachineDefinitionBuilder.In("C").ExecuteOnEntry(() => arrived = true);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState("A")
                     .Build()
                     .CreatePassiveStateMachine();
-
-                machine.Initialize("A");
             });
 
             "when firing a priority event onto the state machine".x(() =>

--- a/source/Appccelerate.StateMachine.Specs/Sync/Persisting.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/Persisting.cs
@@ -121,7 +121,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
             "when a not started state machine is loaded".x(() =>
             {
                 var loader = new StateMachineLoader<State>();
-                loader.SetCurrentState(new Initializable<State>());
+                loader.SetCurrentState(Initializable<State>.UnInitialized());
                 loader.SetHistoryStates(new Dictionary<State, State>());
 
                 var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<State, Event>();
@@ -200,7 +200,9 @@ namespace Appccelerate.StateMachine.Specs.Sync
             stateMachineSaver
                 .CurrentStateId
                 .Should()
-                .Match<Initializable<string>>(actual => actual.IsInitialized && actual.Value == "B");
+                .Match<Initializable<string>>(currentState =>
+                    currentState.IsInitialized
+                    && currentState.ExtractOrThrow() == "B");
         }
 
         private static void SetupStates(StateMachineDefinitionBuilder<State, Event> builder)

--- a/source/Appccelerate.StateMachine.Specs/Sync/Reporting.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/Reporting.cs
@@ -20,7 +20,6 @@ namespace Appccelerate.StateMachine.Specs.Sync
 {
     using System.Collections.Generic;
     using FakeItEasy;
-    using Infrastructure;
     using Machine;
     using Machine.States;
     using Xbehave;
@@ -45,7 +44,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
 
             "it should call the passed reporter".x(() =>
                 A.CallTo(() =>
-                        report.Report(A<string>._, A<IEnumerable<IStateDefinition<string, int>>>._, A<Initializable<string>>._))
+                        report.Report(A<string>._, A<IEnumerable<IStateDefinition<string, int>>>._, A<string>._))
                     .MustHaveHappened());
         }
     }

--- a/source/Appccelerate.StateMachine.Specs/Sync/Reporting.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/Reporting.cs
@@ -33,6 +33,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
         {
             "establish a state machine".x(() =>
                 machine = new StateMachineDefinitionBuilder<string, int>()
+                    .WithInitialState("initial")
                     .Build()
                     .CreatePassiveStateMachine());
 

--- a/source/Appccelerate.StateMachine.Specs/Sync/StartStop.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/StartStop.cs
@@ -34,7 +34,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
         [Background]
         public void Background()
         {
-            "establish initialized state machine".x(() =>
+            "establish a state machine".x(() =>
             {
                 var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<int, int>();
                 stateMachineDefinitionBuilder
@@ -46,13 +46,12 @@ namespace Appccelerate.StateMachine.Specs.Sync
                         .On(Event)
                         .Goto(A);
                 this.machine = stateMachineDefinitionBuilder
+                    .WithInitialState(A)
                     .Build()
                     .CreatePassiveStateMachine();
 
                 this.extension = new RecordEventsExtension();
                 this.machine.AddExtension(this.extension);
-
-                this.machine.Initialize(A);
             });
         }
 

--- a/source/Appccelerate.StateMachine.Specs/Sync/StateMachineExtensions.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/StateMachineExtensions.cs
@@ -31,7 +31,10 @@ namespace Appccelerate.StateMachine.Specs.Sync
         {
             "establish a state machine".x(() =>
             {
-                machine = new StateMachineDefinitionBuilder<string, int>()
+                var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<string, int>();
+                stateMachineDefinitionBuilder.In("initial");
+                machine = stateMachineDefinitionBuilder
+                    .WithInitialState("initial")
                     .Build()
                     .CreatePassiveStateMachine();
 
@@ -41,7 +44,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
             "when adding an extension".x(() =>
             {
                 machine.AddExtension(extension);
-                machine.Initialize("initial");
+                machine.Start();
             });
 
             "it should notify extension about internal events".x(() =>
@@ -56,7 +59,10 @@ namespace Appccelerate.StateMachine.Specs.Sync
         {
             "establish a state machine with an extension".x(() =>
             {
-                machine = new StateMachineDefinitionBuilder<string, int>()
+                var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<string, int>();
+                stateMachineDefinitionBuilder.In("initial");
+                machine = stateMachineDefinitionBuilder
+                    .WithInitialState("initial")
                     .Build()
                     .CreatePassiveStateMachine();
 
@@ -67,7 +73,7 @@ namespace Appccelerate.StateMachine.Specs.Sync
             "when clearing all extensions from the state machine".x(() =>
             {
                 machine.ClearExtensions();
-                machine.Initialize("initial");
+                machine.Start();
             });
 
             "it should not anymore notify extension about internal events".x(() =>

--- a/source/Appccelerate.StateMachine.Specs/Sync/Transitions.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/Transitions.cs
@@ -52,12 +52,12 @@ namespace Appccelerate.StateMachine.Specs.Sync
                     .In(DestinationState)
                         .ExecuteOnEntry(() => entryActionExecuted = true);
                 machine = stateMachineDefinitionBuilder
+                    .WithInitialState(SourceState)
                     .Build()
                     .CreatePassiveStateMachine();
 
                 machine.AddExtension(CurrentStateExtension);
 
-                machine.Initialize(SourceState);
                 machine.Start();
             });
 

--- a/source/Appccelerate.StateMachine/ActiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/ActiveStateMachine.cs
@@ -193,16 +193,7 @@ namespace Appccelerate.StateMachine
 
             void SetCurrentState()
             {
-                if (loadedCurrentState.IsInitialized)
-                {
-                    this.stateContainer.CurrentState =
-                        Initializable<IStateDefinition<TState, TEvent>>.Initialized(
-                            this.stateDefinitions[loadedCurrentState.Value]);
-                }
-                else
-                {
-                    this.stateContainer.CurrentState = Initializable<IStateDefinition<TState, TEvent>>.UnInitialized();
-                }
+                this.stateContainer.CurrentState = loadedCurrentState.Map(x => this.stateDefinitions[x]);
             }
 
             void LoadHistoryStates()

--- a/source/Appccelerate.StateMachine/ActiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/ActiveStateMachine.cs
@@ -207,8 +207,10 @@ namespace Appccelerate.StateMachine
                         Initializable<IStateDefinition<TState, TEvent>>.Initialized(
                             this.stateDefinitions[loadedCurrentState.Value]);
                 }
-
-                this.stateContainer.CurrentState = Initializable<IStateDefinition<TState, TEvent>>.UnInitialized();
+                else
+                {
+                    this.stateContainer.CurrentState = Initializable<IStateDefinition<TState, TEvent>>.UnInitialized();
+                }
             }
 
             void LoadHistoryStates()

--- a/source/Appccelerate.StateMachine/ActiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/ActiveStateMachine.cs
@@ -21,10 +21,8 @@ namespace Appccelerate.StateMachine
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using Infrastructure;
     using Machine;
     using Machine.Events;
-    using Machine.States;
     using Persistence;
 
     /// <summary>
@@ -162,7 +160,7 @@ namespace Appccelerate.StateMachine
         {
             Guard.AgainstNullArgument(nameof(stateMachineSaver), stateMachineSaver);
 
-            stateMachineSaver.SaveCurrentState(this.stateContainer.CurrentStateIdNew);
+            stateMachineSaver.SaveCurrentState(this.stateContainer.CurrentStateId);
 
             var historyStates = this.stateContainer
                 .LastActiveStates

--- a/source/Appccelerate.StateMachine/ActiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/ActiveStateMachine.cs
@@ -155,14 +155,6 @@ namespace Appccelerate.StateMachine
         }
 
         /// <summary>
-        /// Initializes the state machine to the specified initial state.
-        /// </summary>
-        /// <param name="initialState">The state to which the state machine is initialized.</param>
-        public void Initialize(TState initialState)
-        {
-        }
-
-        /// <summary>
         /// Saves the current state and history states to a persisted state. Can be restored using <see cref="Load"/>.
         /// </summary>
         /// <param name="stateMachineSaver">Data to be persisted is passed to the saver.</param>

--- a/source/Appccelerate.StateMachine/AsyncActiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/AsyncActiveStateMachine.cs
@@ -152,15 +152,6 @@ namespace Appccelerate.StateMachine
         }
 
         /// <summary>
-        /// Initializes the state machine to the specified initial state.
-        /// </summary>
-        /// <param name="initialState">The state to which the state machine is initialized.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task Initialize(TState initialState)
-        {
-        }
-
-        /// <summary>
         /// Saves the current state and history states to a persisted state. Can be restored using <see cref="Load"/>.
         /// </summary>
         /// <param name="stateMachineSaver">Data to be persisted is passed to the saver.</param>

--- a/source/Appccelerate.StateMachine/AsyncMachine/AsyncExtensionBase.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/AsyncExtensionBase.cs
@@ -91,28 +91,6 @@ namespace Appccelerate.StateMachine.AsyncMachine
         }
 
         /// <summary>
-        /// Called when the state machine is initializing.
-        /// </summary>
-        /// <param name="stateMachine">The state machine.</param>
-        /// <param name="initialState">The initial state. Can be replaced by the extension.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public virtual Task InitializingStateMachine(IStateMachineInformation<TState, TEvent> stateMachine, ref TState initialState)
-        {
-            return TaskEx.Completed;
-        }
-
-        /// <summary>
-        /// Called when the state machine was initialized.
-        /// </summary>
-        /// <param name="stateMachine">The state machine.</param>
-        /// <param name="initialState">The initial state.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public virtual Task InitializedStateMachine(IStateMachineInformation<TState, TEvent> stateMachine, TState initialState)
-        {
-            return TaskEx.Completed;
-        }
-
-        /// <summary>
         /// Called when the state machine enters the initial state.
         /// </summary>
         /// <param name="stateMachine">The state machine.</param>
@@ -317,7 +295,7 @@ namespace Appccelerate.StateMachine.AsyncMachine
 
         public virtual void Loaded(
             IStateMachineInformation<TState, TEvent> stateMachineInformation,
-            Initializable<TState> loadedCurrentState,
+            IInitializable<TState> loadedCurrentState,
             IReadOnlyDictionary<TState, TState> loadedHistoryStates)
         {
         }

--- a/source/Appccelerate.StateMachine/AsyncMachine/ExceptionMessages.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/ExceptionMessages.cs
@@ -28,15 +28,9 @@ namespace Appccelerate.StateMachine.AsyncMachine
     /// </summary>
     public static class ExceptionMessages
     {
-        /// <summary>
-        /// Value is not initialized.
-        /// </summary>
-        public const string ValueNotInitialized = "Value is not initialized";
+        public const string InitialStateNotConfigured = "Initial state is not configured.";
 
-        /// <summary>
-        /// Value is already initialized.
-        /// </summary>
-        public const string ValueAlreadyInitialized = "Value is already initialized";
+        public const string ValueNotInitialized = "Value is not initialized";
 
         /// <summary>
         /// State machine is already initialized.

--- a/source/Appccelerate.StateMachine/AsyncMachine/IExtension.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/IExtension.cs
@@ -79,26 +79,6 @@ namespace Appccelerate.StateMachine.AsyncMachine
             IStateDefinition<TState, TEvent> newStateDefinition);
 
         /// <summary>
-        /// Called when the state machine is initializing.
-        /// </summary>
-        /// <param name="stateMachine">The state machine.</param>
-        /// <param name="initialState">The initial state. Can be replaced by the extension.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task InitializingStateMachine(
-            IStateMachineInformation<TState, TEvent> stateMachine,
-            ref TState initialState);
-
-        /// <summary>
-        /// Called when the state machine was initialized.
-        /// </summary>
-        /// <param name="stateMachine">The state machine.</param>
-        /// <param name="initialState">The initial state.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task InitializedStateMachine(
-            IStateMachineInformation<TState, TEvent> stateMachine,
-            TState initialState);
-
-        /// <summary>
         /// Called when the state machine enters the initial state.
         /// </summary>
         /// <param name="stateMachine">The state machine.</param>
@@ -292,7 +272,7 @@ namespace Appccelerate.StateMachine.AsyncMachine
 
         void Loaded(
             IStateMachineInformation<TState, TEvent> stateMachineInformation,
-            Initializable<TState> loadedCurrentState,
+            IInitializable<TState> loadedCurrentState,
             IReadOnlyDictionary<TState, TState> loadedHistoryStates);
     }
 }

--- a/source/Appccelerate.StateMachine/AsyncMachine/IStateMachineReport.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/IStateMachineReport.cs
@@ -20,7 +20,6 @@ namespace Appccelerate.StateMachine.AsyncMachine
 {
     using System;
     using System.Collections.Generic;
-    using Infrastructure;
     using States;
 
     /// <summary>
@@ -38,6 +37,6 @@ namespace Appccelerate.StateMachine.AsyncMachine
         /// <param name="name">The name of the state machine.</param>
         /// <param name="stateDefinitions">The states.</param>
         /// <param name="initialStateId">The initial state id.</param>
-        void Report(string name, IEnumerable<IStateDefinition<TState, TEvent>> stateDefinitions, Initializable<TState> initialStateId);
+        void Report(string name, IEnumerable<IStateDefinition<TState, TEvent>> stateDefinitions, TState initialStateId);
     }
 }

--- a/source/Appccelerate.StateMachine/AsyncMachine/Reports/CsvStateMachineReportGenerator.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/Reports/CsvStateMachineReportGenerator.cs
@@ -23,7 +23,6 @@ namespace Appccelerate.StateMachine.AsyncMachine.Reports
     using System.IO;
     using System.Linq;
     using AsyncMachine;
-    using Infrastructure;
     using States;
 
     /// <summary>
@@ -56,7 +55,7 @@ namespace Appccelerate.StateMachine.AsyncMachine.Reports
         /// <param name="name">The name of the state machine.</param>
         /// <param name="states">The states.</param>
         /// <param name="initialStateId">The initial state id.</param>
-        public void Report(string name, IEnumerable<IStateDefinition<TState, TEvent>> states, Initializable<TState> initialStateId)
+        public void Report(string name, IEnumerable<IStateDefinition<TState, TEvent>> states, TState initialStateId)
         {
             states = states.ToList();
 

--- a/source/Appccelerate.StateMachine/AsyncMachine/Reports/StateMachineReportGenerator.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/Reports/StateMachineReportGenerator.cs
@@ -23,7 +23,6 @@ namespace Appccelerate.StateMachine.AsyncMachine.Reports
     using System.Globalization;
     using System.Linq;
     using System.Text;
-    using Infrastructure;
     using States;
     using Transitions;
 
@@ -48,18 +47,17 @@ namespace Appccelerate.StateMachine.AsyncMachine.Reports
         /// <param name="name">The name of the state machine.</param>
         /// <param name="states">The states.</param>
         /// <param name="initialStateId">The initial state id.</param>
-        public void Report(string name, IEnumerable<IStateDefinition<TState, TEvent>> states, Initializable<TState> initialStateId)
+        public void Report(string name, IEnumerable<IStateDefinition<TState, TEvent>> states, TState initialStateId)
         {
             states = states.ToList();
 
             Guard.AgainstNullArgument("states", states);
-            Guard.AgainstNullArgument("initialStateId", initialStateId);
 
             var report = new StringBuilder();
 
             const string indentation = "    ";
 
-            report.AppendFormat("{0}: initial state = {1}{2}", name, initialStateId.IsInitialized ? initialStateId.Value.ToString() : "none", Environment.NewLine);
+            report.AppendFormat("{0}: initial state = {1}{2}", name, initialStateId.ToString(), Environment.NewLine);
 
             // write states
             var rootStates = states.Where(state => state.SuperState == null);

--- a/source/Appccelerate.StateMachine/AsyncMachine/Reports/YEdStateMachineReportGenerator.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/Reports/YEdStateMachineReportGenerator.cs
@@ -25,7 +25,6 @@ namespace Appccelerate.StateMachine.AsyncMachine.Reports
     using System.Linq;
     using System.Xml.Linq;
     using AsyncMachine;
-    using Infrastructure;
     using States;
     using Transitions;
 
@@ -49,7 +48,7 @@ namespace Appccelerate.StateMachine.AsyncMachine.Reports
 
         private int edgeId;
 
-        private Initializable<TState> initialStateId;
+        private TState initialState;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="YEdStateMachineReportGenerator&lt;TState, TEvent&gt;"/> class.
@@ -66,13 +65,13 @@ namespace Appccelerate.StateMachine.AsyncMachine.Reports
         /// <param name="name">The name of the state machine.</param>
         /// <param name="states">The states.</param>
         /// <param name="initialState">The initial state id.</param>
-        public void Report(string name, IEnumerable<IStateDefinition<TState, TEvent>> states, Initializable<TState> initialState)
+        public void Report(string name, IEnumerable<IStateDefinition<TState, TEvent>> states, TState initialState)
         {
             var statesList = states.ToList();
 
             this.edgeId = 0;
 
-            this.initialStateId = initialState;
+            this.initialState = initialState;
             Guard.AgainstNullArgument("states", statesList);
 
             XElement graph = CreateGraph();
@@ -244,7 +243,8 @@ namespace Appccelerate.StateMachine.AsyncMachine.Reports
 
         private bool DetermineWhetherThisIsAnInitialState(IStateDefinition<TState, TEvent> state)
         {
-            return (this.initialStateId.IsInitialized && state.Id.ToString() == this.initialStateId.Value.ToString()) || (state.SuperState != null && state.SuperState.InitialState == state);
+            return state.Id.ToString() == this.initialState.ToString()
+                   || (state.SuperState != null && state.SuperState.InitialState == state);
         }
     }
 }

--- a/source/Appccelerate.StateMachine/AsyncMachine/StateContainer.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/StateContainer.cs
@@ -53,6 +53,8 @@ namespace Appccelerate.StateMachine.AsyncMachine
 
         public TState CurrentStateId => this.CurrentState.Id;
 
+        public IInitializable<TState> CurrentStateIdNew => throw new InvalidOperationException();
+
         public IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> LastActiveStates => this.lastActiveStates;
 
         public async Task ForEach(Func<IExtension<TState, TEvent>, Task> action)

--- a/source/Appccelerate.StateMachine/AsyncMachine/StateContainer.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/StateContainer.cs
@@ -41,19 +41,16 @@ namespace Appccelerate.StateMachine.AsyncMachine
         public StateContainer(string name)
         {
             this.Name = name;
+            this.CurrentState = Initializable<IStateDefinition<TState, TEvent>>.UnInitialized();
         }
 
         public string Name { get; }
 
         public List<IExtension<TState, TEvent>> Extensions { get; } = new List<IExtension<TState, TEvent>>();
 
-        public Initializable<TState> InitialStateId { get; } = new Initializable<TState>();
+        public Initializable<IStateDefinition<TState, TEvent>> CurrentState { get; set; }
 
-        public IStateDefinition<TState, TEvent> CurrentState { get; set; }
-
-        public TState CurrentStateId => this.CurrentState.Id;
-
-        public IInitializable<TState> CurrentStateIdNew => throw new InvalidOperationException();
+        public IInitializable<TState> CurrentStateId => this.CurrentState.Map(x => x.Id);
 
         public IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> LastActiveStates => this.lastActiveStates;
 

--- a/source/Appccelerate.StateMachine/AsyncMachine/StateMachine.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/StateMachine.cs
@@ -21,6 +21,7 @@ namespace Appccelerate.StateMachine.AsyncMachine
     using System;
     using System.Threading.Tasks;
     using Events;
+    using Infrastructure;
     using States;
 
     /// <summary>
@@ -72,9 +73,9 @@ namespace Appccelerate.StateMachine.AsyncMachine
             StateContainer<TState, TEvent> stateContainer,
             IStateMachineInformation<TState, TEvent> stateMachineInformation)
         {
-            var oldState = stateContainer.CurrentState;
+            var oldState = stateContainer.CurrentState.ExtractOr(null);
 
-            stateContainer.CurrentState = newState;
+            stateContainer.CurrentState = Initializable<IStateDefinition<TState, TEvent>>.Initialized(newState);
 
             await stateContainer
                 .ForEach(extension =>
@@ -83,45 +84,27 @@ namespace Appccelerate.StateMachine.AsyncMachine
         }
 
         /// <summary>
-        /// Initializes the state machine by setting the specified initial state.
-        /// </summary>
-        /// <param name="initialState">The initial state of the state machine.</param>
-        /// <param name="stateContainer">Contains all mutable state of of the state machine.</param>
-        /// <param name="stateMachineInformation">The state machine information.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task Initialize(TState initialState, StateContainer<TState, TEvent> stateContainer, IStateMachineInformation<TState, TEvent> stateMachineInformation)
-        {
-            await stateContainer.ForEach(extension => extension.InitializingStateMachine(stateMachineInformation, ref initialState))
-                .ConfigureAwait(false);
-
-            Initialize(initialState, stateContainer);
-
-            await stateContainer.ForEach(extension => extension.InitializedStateMachine(stateMachineInformation, initialState))
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Enters the initial state that was previously set with <see cref="Initialize(TState, StateContainer{TState,TEvent}, IStateMachineInformation{TState,TEvent})"/>.
+        /// Enters the initial state state as specified with <see cref="initialState"/>.
         /// </summary>
         /// <param name="stateContainer">Contains all mutable state of of the state machine.</param>
         /// <param name="stateMachineInformation">The state machine information.</param>
         /// <param name="stateDefinitions">The definitions for all states of this state Machine.</param>
+        /// <param name="initialState">The initial state the state machine should enter.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task EnterInitialState(
             StateContainer<TState, TEvent> stateContainer,
             IStateMachineInformation<TState, TEvent> stateMachineInformation,
-            IStateDefinitionDictionary<TState, TEvent> stateDefinitions)
+            IStateDefinitionDictionary<TState, TEvent> stateDefinitions,
+            TState initialState)
         {
-            CheckThatStateMachineIsInitialized(stateContainer);
-
-            await stateContainer.ForEach(extension => extension.EnteringInitialState(stateMachineInformation, stateContainer.InitialStateId.Value))
+            await stateContainer.ForEach(extension => extension.EnteringInitialState(stateMachineInformation, initialState))
                 .ConfigureAwait(false);
 
             var context = this.factory.CreateTransitionContext(null, new Missable<TEvent>(), Missing.Value, this);
-            await this.EnterInitialState(context, stateContainer, stateMachineInformation, stateDefinitions)
+            await this.EnterInitialState(context, stateContainer, stateMachineInformation, stateDefinitions, initialState)
                 .ConfigureAwait(false);
 
-            await stateContainer.ForEach(extension => extension.EnteredInitialState(stateMachineInformation, stateContainer.InitialStateId.Value, context))
+            await stateContainer.ForEach(extension => extension.EnteredInitialState(stateMachineInformation, initialState, context))
                 .ConfigureAwait(false);
         }
 
@@ -141,14 +124,14 @@ namespace Appccelerate.StateMachine.AsyncMachine
             IStateMachineInformation<TState, TEvent> stateMachineInformation,
             IStateDefinitionDictionary<TState, TEvent> stateDefinitions)
         {
-            CheckThatStateMachineIsInitialized(stateContainer);
             CheckThatStateMachineHasEnteredInitialState(stateContainer);
 
             await stateContainer.ForEach(extension => extension.FiringEvent(stateMachineInformation, ref eventId, ref eventArgument))
                 .ConfigureAwait(false);
 
-            var context = this.factory.CreateTransitionContext(stateContainer.CurrentState, new Missable<TEvent>(eventId), eventArgument, this);
-            var result = await this.stateLogic.Fire(stateContainer.CurrentState, context, stateContainer)
+            var currentState = stateContainer.CurrentState.ExtractOrThrow();
+            var context = this.factory.CreateTransitionContext(currentState, new Missable<TEvent>(eventId), eventArgument, this);
+            var result = await this.stateLogic.Fire(currentState, context, stateContainer)
                 .ConfigureAwait(false);
 
             if (!result.Fired)
@@ -212,34 +195,20 @@ namespace Appccelerate.StateMachine.AsyncMachine
             this.RaiseEvent(
                 this.TransitionCompleted,
                 new TransitionCompletedEventArgs<TState, TEvent>(
-                    stateMachineInformation.CurrentStateId,
+                    stateMachineInformation.CurrentStateId.ExtractOrThrow(),
                     transitionContext),
                 transitionContext,
                 true);
-        }
-
-        /// <summary>
-        /// Initializes the state machine by setting the specified initial state.
-        /// </summary>
-        /// <param name="initialState">The initial state.</param>
-        /// <param name="stateContainer">Contains all mutable state of of the state machine.</param>
-        private static void Initialize(TState initialState, StateContainer<TState, TEvent> stateContainer)
-        {
-            if (stateContainer.InitialStateId.IsInitialized)
-            {
-                throw new InvalidOperationException(ExceptionMessages.StateMachineIsAlreadyInitialized);
-            }
-
-            stateContainer.InitialStateId.Value = initialState;
         }
 
         private async Task EnterInitialState(
             ITransitionContext<TState, TEvent> context,
             StateContainer<TState, TEvent> stateContainer,
             IStateMachineInformation<TState, TEvent> stateMachineInformation,
-            IStateDefinitionDictionary<TState, TEvent> stateDefinitions)
+            IStateDefinitionDictionary<TState, TEvent> stateDefinitions,
+            TState initialStateId)
         {
-            var initialState = stateDefinitions[stateContainer.InitialStateId.Value];
+            var initialState = stateDefinitions[initialStateId];
             var initializer = this.factory.CreateStateMachineInitializer(initialState, context);
             var newStateId = await initializer.EnterInitialState(this.stateLogic, stateContainer).
                 ConfigureAwait(false);
@@ -271,17 +240,9 @@ namespace Appccelerate.StateMachine.AsyncMachine
             }
         }
 
-        private static void CheckThatStateMachineIsInitialized(StateContainer<TState, TEvent> stateContainer)
-        {
-            if (stateContainer.CurrentState == null && !stateContainer.InitialStateId.IsInitialized)
-            {
-                throw new InvalidOperationException(ExceptionMessages.StateMachineNotInitialized);
-            }
-        }
-
         private static void CheckThatStateMachineHasEnteredInitialState(StateContainer<TState, TEvent> stateContainer)
         {
-            if (stateContainer.CurrentState == null)
+            if (!stateContainer.CurrentState.IsInitialized)
             {
                 throw new InvalidOperationException(ExceptionMessages.StateMachineHasNotYetEnteredInitialState);
             }

--- a/source/Appccelerate.StateMachine/AsyncMachine/StateMachine.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/StateMachine.cs
@@ -84,7 +84,7 @@ namespace Appccelerate.StateMachine.AsyncMachine
         }
 
         /// <summary>
-        /// Enters the initial state state as specified with <see cref="initialState"/>.
+        /// Enters the initial state as specified with <paramref name="initialState"/>.
         /// </summary>
         /// <param name="stateContainer">Contains all mutable state of of the state machine.</param>
         /// <param name="stateMachineInformation">The state machine information.</param>

--- a/source/Appccelerate.StateMachine/AsyncMachine/StateMachineDefinition.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/StateMachineDefinition.cs
@@ -29,13 +29,16 @@ namespace Appccelerate.StateMachine.AsyncMachine
     {
         private readonly IStateDefinitionDictionary<TState, TEvent> stateDefinitions;
         private readonly IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates;
+        private readonly TState initialState;
 
         public StateMachineDefinition(
             IStateDefinitionDictionary<TState, TEvent> stateDefinitions,
-            IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates)
+            IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates,
+            TState initialState)
         {
             this.stateDefinitions = stateDefinitions;
             this.initiallyLastActiveStates = initiallyLastActiveStates;
+            this.initialState = initialState;
         }
 
         public AsyncPassiveStateMachine<TState, TEvent> CreatePassiveStateMachine()
@@ -59,7 +62,7 @@ namespace Appccelerate.StateMachine.AsyncMachine
             var standardFactory = new StandardFactory<TState, TEvent>();
             var stateMachine = new StateMachine<TState, TEvent>(standardFactory, stateLogic);
 
-            return new AsyncPassiveStateMachine<TState, TEvent>(stateMachine, stateContainer, this.stateDefinitions);
+            return new AsyncPassiveStateMachine<TState, TEvent>(stateMachine, stateContainer, this.stateDefinitions, this.initialState);
         }
 
         public AsyncActiveStateMachine<TState, TEvent> CreateActiveStateMachine()
@@ -83,7 +86,7 @@ namespace Appccelerate.StateMachine.AsyncMachine
             var standardFactory = new StandardFactory<TState, TEvent>();
             var stateMachine = new StateMachine<TState, TEvent>(standardFactory, stateLogic);
 
-            return new AsyncActiveStateMachine<TState, TEvent>(stateMachine, stateContainer, this.stateDefinitions);
+            return new AsyncActiveStateMachine<TState, TEvent>(stateMachine, stateContainer, this.stateDefinitions, this.initialState);
         }
     }
 }

--- a/source/Appccelerate.StateMachine/AsyncMachine/StateMachineDefinitionBuilder.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/StateMachineDefinitionBuilder.cs
@@ -30,6 +30,8 @@ namespace Appccelerate.StateMachine.AsyncMachine
         private readonly StandardFactory<TState, TEvent> factory = new StandardFactory<TState, TEvent>();
         private readonly ImplicitAddIfNotAvailableStateDefinitionDictionary<TState, TEvent> stateDefinitionDictionary = new ImplicitAddIfNotAvailableStateDefinitionDictionary<TState, TEvent>();
         private readonly Dictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates = new Dictionary<TState, IStateDefinition<TState, TEvent>>();
+        private TState initialState;
+        private bool isInitialStateConfigured;
 
         public IEntryActionSyntax<TState, TEvent> In(TState state)
         {
@@ -41,10 +43,22 @@ namespace Appccelerate.StateMachine.AsyncMachine
             return new HierarchyBuilder<TState, TEvent>(superStateId, this.stateDefinitionDictionary, this.initiallyLastActiveStates);
         }
 
+        public StateMachineDefinitionBuilder<TState, TEvent> WithInitialState(TState initialStateToUse)
+        {
+            this.initialState = initialStateToUse;
+            this.isInitialStateConfigured = true;
+            return this;
+        }
+
         public StateMachineDefinition<TState, TEvent> Build()
         {
+            if (!this.isInitialStateConfigured)
+            {
+                throw new InvalidOperationException(ExceptionMessages.InitialStateNotConfigured);
+            }
+
             var stateDefinitions = new StateDefinitionDictionary<TState, TEvent>(this.stateDefinitionDictionary.ReadOnlyDictionary);
-            return new StateMachineDefinition<TState, TEvent>(stateDefinitions, this.initiallyLastActiveStates);
+            return new StateMachineDefinition<TState, TEvent>(stateDefinitions, this.initiallyLastActiveStates, this.initialState);
         }
     }
 }

--- a/source/Appccelerate.StateMachine/AsyncPassiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/AsyncPassiveStateMachine.cs
@@ -22,7 +22,6 @@ namespace Appccelerate.StateMachine
     using System.Threading.Tasks;
     using AsyncMachine;
     using AsyncMachine.Events;
-    using Infrastructure;
     using Persistence;
 
     public class AsyncPassiveStateMachine<TState, TEvent> : IAsyncStateMachine<TState, TEvent>
@@ -38,18 +37,20 @@ namespace Appccelerate.StateMachine
 
         private readonly IStateDefinitionDictionary<TState, TEvent> stateDefinitions;
 
-        private bool initialized;
+        private readonly TState initialState;
+
         private bool executing;
-        private bool pendingInitialization;
 
         public AsyncPassiveStateMachine(
             StateMachine<TState, TEvent> stateMachine,
             StateContainer<TState, TEvent> stateContainer,
-            IStateDefinitionDictionary<TState, TEvent> stateDefinitions)
+            IStateDefinitionDictionary<TState, TEvent> stateDefinitions,
+            TState initialState)
         {
             this.stateMachine = stateMachine;
             this.stateContainer = stateContainer;
             this.stateDefinitions = stateDefinitions;
+            this.initialState = initialState;
             this.events = new ConcurrentQueue<EventInformation<TEvent>>();
             this.priorityEvents = new ConcurrentStack<EventInformation<TEvent>>();
         }
@@ -160,13 +161,6 @@ namespace Appccelerate.StateMachine
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task Initialize(TState initialState)
         {
-            this.CheckThatNotAlreadyInitialized();
-
-            this.initialized = true;
-            this.pendingInitialization = true;
-
-            await this.stateMachine.Initialize(initialState, this.stateContainer, this.stateContainer)
-                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -177,8 +171,6 @@ namespace Appccelerate.StateMachine
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task Start()
         {
-            this.CheckThatStateMachineIsInitialized();
-
             this.IsRunning = true;
 
             await this.stateContainer.ForEach(extension => extension.StartedStateMachine(this.stateContainer))
@@ -193,7 +185,7 @@ namespace Appccelerate.StateMachine
         /// <param name="reportGenerator">The report generator.</param>
         public void Report(IStateMachineReport<TState, TEvent> reportGenerator)
         {
-            reportGenerator.Report(this.ToString(), this.stateDefinitions.Values, this.stateContainer.InitialStateId);
+            reportGenerator.Report(this.ToString(), this.stateDefinitions.Values, this.initialState);
         }
 
         public override string ToString()
@@ -239,10 +231,7 @@ namespace Appccelerate.StateMachine
         {
             Guard.AgainstNullArgument(nameof(stateMachineSaver), stateMachineSaver);
 
-            await stateMachineSaver.SaveCurrentState(
-                    this.stateContainer.CurrentState != null
-                        ? new Initializable<TState> { Value = this.stateContainer.CurrentStateId }
-                        : new Initializable<TState>())
+            await stateMachineSaver.SaveCurrentState(this.stateContainer.CurrentStateId)
                 .ConfigureAwait(false);
 
             var historyStates = this.stateContainer
@@ -265,27 +254,17 @@ namespace Appccelerate.StateMachine
             Guard.AgainstNullArgument(nameof(stateMachineLoader), stateMachineLoader);
 
             this.CheckThatNotAlreadyInitialized();
-            this.CheckThatStateMachineIsNotAlreadyInitialized();
 
             var loadedCurrentState = await stateMachineLoader.LoadCurrentState().ConfigureAwait(false);
             var historyStates = await stateMachineLoader.LoadHistoryStates().ConfigureAwait(false);
 
-            var loadedStateMachineWasInitialized = SetCurrentState();
+            SetCurrentState();
             LoadHistoryStates();
             NotifyExtensions();
 
-            this.initialized = loadedStateMachineWasInitialized;
-
-            bool SetCurrentState()
+            void SetCurrentState()
             {
-                if (loadedCurrentState.IsInitialized)
-                {
-                    this.stateContainer.CurrentState = this.stateDefinitions[loadedCurrentState.Value];
-                    return true;
-                }
-
-                this.stateContainer.CurrentState = null;
-                return false;
+                this.stateContainer.CurrentState = loadedCurrentState.Map(x => this.stateDefinitions[x]);
             }
 
             void LoadHistoryStates()
@@ -316,23 +295,7 @@ namespace Appccelerate.StateMachine
 
         private void CheckThatNotAlreadyInitialized()
         {
-            if (this.initialized)
-            {
-                throw new InvalidOperationException(ExceptionMessages.StateMachineIsAlreadyInitialized);
-            }
-        }
-
-        private void CheckThatStateMachineIsInitialized()
-        {
-            if (!this.initialized)
-            {
-                throw new InvalidOperationException(ExceptionMessages.StateMachineNotInitialized);
-            }
-        }
-
-        private void CheckThatStateMachineIsNotAlreadyInitialized()
-        {
-            if (this.stateContainer.CurrentState != null || this.stateContainer.InitialStateId.IsInitialized)
+            if (this.stateContainer.CurrentState.IsInitialized)
             {
                 throw new InvalidOperationException(ExceptionMessages.StateMachineIsAlreadyInitialized);
             }
@@ -358,7 +321,8 @@ namespace Appccelerate.StateMachine
 
         private async Task ProcessQueuedEvents()
         {
-            await this.InitializeStateMachineIfInitializationIsPending().ConfigureAwait(false);
+            await this.InitializeStateMachineIfInitializationIsPending()
+                .ConfigureAwait(false);
 
             while (this.priorityEvents.TryPop(out var eventInformation))
             {
@@ -385,15 +349,13 @@ namespace Appccelerate.StateMachine
 
         private async Task InitializeStateMachineIfInitializationIsPending()
         {
-            if (!this.pendingInitialization)
+            if (this.stateContainer.CurrentState.IsInitialized)
             {
                 return;
             }
 
-            await this.stateMachine.EnterInitialState(this.stateContainer, this.stateContainer, this.stateDefinitions)
+            await this.stateMachine.EnterInitialState(this.stateContainer, this.stateContainer, this.stateDefinitions, this.initialState)
                 .ConfigureAwait(false);
-
-            this.pendingInitialization = false;
         }
     }
 }

--- a/source/Appccelerate.StateMachine/AsyncPassiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/AsyncPassiveStateMachine.cs
@@ -155,15 +155,6 @@ namespace Appccelerate.StateMachine
         }
 
         /// <summary>
-        /// Initializes the state machine to the specified initial state.
-        /// </summary>
-        /// <param name="initialState">The state to which the state machine is initialized.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task Initialize(TState initialState)
-        {
-        }
-
-        /// <summary>
         /// Starts the state machine. Events will be processed.
         /// If the state machine is not started then the events will be queued until the state machine is started.
         /// Already queued events are processed.

--- a/source/Appccelerate.StateMachine/Extensions/ExtensionBase.cs
+++ b/source/Appccelerate.StateMachine/Extensions/ExtensionBase.cs
@@ -81,24 +81,6 @@ namespace Appccelerate.StateMachine.Extensions
         }
 
         /// <summary>
-        /// Called when the state machine is initializing.
-        /// </summary>
-        /// <param name="stateMachine">The state machine.</param>
-        /// <param name="initialState">The initial state. Can be replaced by the extension.</param>
-        public virtual void InitializingStateMachine(IStateMachineInformation<TState, TEvent> stateMachine, ref TState initialState)
-        {
-        }
-
-        /// <summary>
-        /// Called when the state machine was initialized.
-        /// </summary>
-        /// <param name="stateMachine">The state machine.</param>
-        /// <param name="initialState">The initial state.</param>
-        public virtual void InitializedStateMachine(IStateMachineInformation<TState, TEvent> stateMachine, TState initialState)
-        {
-        }
-
-        /// <summary>
         /// Called when the state machine enters the initial state.
         /// </summary>
         /// <param name="stateMachine">The state machine.</param>
@@ -272,7 +254,7 @@ namespace Appccelerate.StateMachine.Extensions
 
         public virtual void Loaded(
             IStateMachineInformation<TState, TEvent> stateMachineInformation,
-            Initializable<TState> loadedCurrentState,
+            IInitializable<TState> loadedCurrentState,
             IReadOnlyDictionary<TState, TState> loadedHistoryStates)
         {
         }

--- a/source/Appccelerate.StateMachine/IAsyncStateMachine.cs
+++ b/source/Appccelerate.StateMachine/IAsyncStateMachine.cs
@@ -90,13 +90,6 @@ namespace Appccelerate.StateMachine
         Task FirePriority(TEvent eventId, object eventArgument);
 
         /// <summary>
-        /// Initializes the state machine to the specified initial state.
-        /// </summary>
-        /// <param name="initialState">The state to which the state machine is initialized.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task Initialize(TState initialState);
-
-        /// <summary>
         /// Starts the state machine. Events will be processed.
         /// If the state machine is not started then the events will be queued until the state machine is started.
         /// Already queued events are processed.

--- a/source/Appccelerate.StateMachine/IStateMachine.cs
+++ b/source/Appccelerate.StateMachine/IStateMachine.cs
@@ -86,12 +86,6 @@ namespace Appccelerate.StateMachine
         void FirePriority(TEvent eventId, object eventArgument);
 
         /// <summary>
-        /// Initializes the state machine to the specified initial state.
-        /// </summary>
-        /// <param name="initialState">The state to which the state machine is initialized.</param>
-        void Initialize(TState initialState);
-
-        /// <summary>
         /// Starts the state machine. Events will be processed.
         /// If the state machine is not started then the events will be queued until the state machine is started.
         /// Already queued events are processed.

--- a/source/Appccelerate.StateMachine/IStateMachineInformation.cs
+++ b/source/Appccelerate.StateMachine/IStateMachineInformation.cs
@@ -19,6 +19,7 @@
 namespace Appccelerate.StateMachine
 {
     using System;
+    using Infrastructure;
 
     /// <summary>
     /// Provides information about a state machine.
@@ -40,6 +41,8 @@ namespace Appccelerate.StateMachine
         /// Gets the id of the current state.
         /// </summary>
         /// <value>The id of the current state.</value>
+        IInitializable<TState> CurrentStateIdNew { get; }
+
         TState CurrentStateId { get; }
     }
 }

--- a/source/Appccelerate.StateMachine/IStateMachineInformation.cs
+++ b/source/Appccelerate.StateMachine/IStateMachineInformation.cs
@@ -41,8 +41,6 @@ namespace Appccelerate.StateMachine
         /// Gets the id of the current state.
         /// </summary>
         /// <value>The id of the current state.</value>
-        IInitializable<TState> CurrentStateIdNew { get; }
-
-        TState CurrentStateId { get; }
+        IInitializable<TState> CurrentStateId { get; }
     }
 }

--- a/source/Appccelerate.StateMachine/Infrastructure/IInitializable.cs
+++ b/source/Appccelerate.StateMachine/Infrastructure/IInitializable.cs
@@ -18,10 +18,16 @@
 
 namespace Appccelerate.StateMachine.Infrastructure
 {
+    using System;
+
     public interface IInitializable<out T>
     {
         T Value { get; }
 
         bool IsInitialized { get; }
+
+        Initializable<TResult> Map<TResult>(Func<T, TResult> func);
+
+        T ExtractOrThrow();
     }
 }

--- a/source/Appccelerate.StateMachine/Infrastructure/IInitializable.cs
+++ b/source/Appccelerate.StateMachine/Infrastructure/IInitializable.cs
@@ -1,5 +1,5 @@
 //-------------------------------------------------------------------------------
-// <copyright file="StateMachineNameReporter.cs" company="Appccelerate">
+// <copyright file="IInitializable.cs" company="Appccelerate">
 //   Copyright (c) 2008-2019 Appccelerate
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,19 +16,12 @@
 // </copyright>
 //-------------------------------------------------------------------------------
 
-namespace Appccelerate.StateMachine.Specs.Sync
+namespace Appccelerate.StateMachine.Infrastructure
 {
-    using System.Collections.Generic;
-    using Machine;
-    using Machine.States;
-
-    public class StateMachineNameReporter : IStateMachineReport<string, int>
+    public interface IInitializable<out T>
     {
-        public string StateMachineName { get; private set; }
+        T Value { get; }
 
-        public void Report(string name, IEnumerable<IStateDefinition<string, int>> states, string initialStateId)
-        {
-            this.StateMachineName = name;
-        }
+        bool IsInitialized { get; }
     }
 }

--- a/source/Appccelerate.StateMachine/Infrastructure/Initializable.cs
+++ b/source/Appccelerate.StateMachine/Infrastructure/Initializable.cs
@@ -19,15 +19,29 @@
 namespace Appccelerate.StateMachine.Infrastructure
 {
     using System;
-    using Appccelerate.StateMachine.Machine;
+    using Machine;
 
     /// <summary>
     /// A value which can be initialized.
     /// </summary>
     /// <typeparam name="T">Type of the value.</typeparam>
-    public class Initializable<T>
+    public class Initializable<T> : IInitializable<T>
     {
         private T value;
+
+        public static Initializable<T> UnInitialized()
+        {
+            return new Initializable<T>();
+        }
+
+        public static Initializable<T> Initialized(T t)
+        {
+            return new Initializable<T>
+            {
+                value = t,
+                IsInitialized = true
+            };
+        }
 
         /// <summary>
         /// Gets or sets the value.

--- a/source/Appccelerate.StateMachine/Infrastructure/Initializable.cs
+++ b/source/Appccelerate.StateMachine/Infrastructure/Initializable.cs
@@ -22,7 +22,7 @@ namespace Appccelerate.StateMachine.Infrastructure
     using Machine;
 
     /// <summary>
-    /// A value which can be initialized.
+    /// A value which can either be initialized or not.
     /// </summary>
     /// <typeparam name="T">Type of the value.</typeparam>
     public class Initializable<T> : IInitializable<T>
@@ -41,6 +41,28 @@ namespace Appccelerate.StateMachine.Infrastructure
                 value = t,
                 IsInitialized = true
             };
+        }
+
+        public Initializable<TResult> Map<TResult>(Func<T, TResult> func)
+        {
+            return
+                this.IsInitialized
+                    ? Initializable<TResult>.Initialized(func(this.value))
+                    : Initializable<TResult>.UnInitialized();
+        }
+
+        public T ExtractOr(T valueIfNotInitialized)
+        {
+            return
+                this.IsInitialized
+                    ? this.value
+                    : valueIfNotInitialized;
+        }
+
+        public T ExtractOrThrow()
+        {
+            this.CheckInitialized();
+            return this.value;
         }
 
         /// <summary>

--- a/source/Appccelerate.StateMachine/Machine/ExceptionMessages.cs
+++ b/source/Appccelerate.StateMachine/Machine/ExceptionMessages.cs
@@ -27,6 +27,8 @@ namespace Appccelerate.StateMachine.Machine
     /// </summary>
     public static class ExceptionMessages
     {
+        public const string InitialStateNotConfigured = "Initial state is not configured.";
+
         /// <summary>
         /// Value is not initialized.
         /// </summary>

--- a/source/Appccelerate.StateMachine/Machine/ExceptionMessages.cs
+++ b/source/Appccelerate.StateMachine/Machine/ExceptionMessages.cs
@@ -45,11 +45,6 @@ namespace Appccelerate.StateMachine.Machine
         public const string StateMachineIsAlreadyInitialized = "state machine is already initialized";
 
         /// <summary>
-        /// State machine is not initialized.
-        /// </summary>
-        public const string StateMachineNotInitialized = "state machine is not initialized";
-
-        /// <summary>
         /// State machine has not yet entered initial state.
         /// </summary>
         public const string StateMachineHasNotYetEnteredInitialState = "Initial state is not yet entered.";

--- a/source/Appccelerate.StateMachine/Machine/IExtension.cs
+++ b/source/Appccelerate.StateMachine/Machine/IExtension.cs
@@ -73,24 +73,6 @@ namespace Appccelerate.StateMachine.Machine
             IStateDefinition<TState, TEvent> newState);
 
         /// <summary>
-        /// Called when the state machine is initializing.
-        /// </summary>
-        /// <param name="stateMachine">The state machine.</param>
-        /// <param name="initialState">The initial state. Can be replaced by the extension.</param>
-        void InitializingStateMachine(
-            IStateMachineInformation<TState, TEvent> stateMachine,
-            ref TState initialState);
-
-        /// <summary>
-        /// Called when the state machine was initialized.
-        /// </summary>
-        /// <param name="stateMachine">The state machine.</param>
-        /// <param name="initialState">The initial state.</param>
-        void InitializedStateMachine(
-            IStateMachineInformation<TState, TEvent> stateMachine,
-            TState initialState);
-
-        /// <summary>
         /// Called when the state machine enters the initial state.
         /// </summary>
         /// <param name="stateMachine">The state machine.</param>
@@ -269,7 +251,7 @@ namespace Appccelerate.StateMachine.Machine
 
         void Loaded(
             IStateMachineInformation<TState, TEvent> stateMachineInformation,
-            Initializable<TState> loadedCurrentState,
+            IInitializable<TState> loadedCurrentState,
             IReadOnlyDictionary<TState, TState> loadedHistoryStates);
     }
 }

--- a/source/Appccelerate.StateMachine/Machine/IStateMachineReport.cs
+++ b/source/Appccelerate.StateMachine/Machine/IStateMachineReport.cs
@@ -20,7 +20,6 @@ namespace Appccelerate.StateMachine.Machine
 {
     using System;
     using System.Collections.Generic;
-    using Infrastructure;
     using States;
 
     /// <summary>

--- a/source/Appccelerate.StateMachine/Machine/IStateMachineReport.cs
+++ b/source/Appccelerate.StateMachine/Machine/IStateMachineReport.cs
@@ -38,6 +38,6 @@ namespace Appccelerate.StateMachine.Machine
         /// <param name="name">The name of the state machine.</param>
         /// <param name="states">The states.</param>
         /// <param name="initialStateId">The initial state id.</param>
-        void Report(string name, IEnumerable<IStateDefinition<TState, TEvent>> states, Initializable<TState> initialStateId);
+        void Report(string name, IEnumerable<IStateDefinition<TState, TEvent>> states, TState initialStateId);
     }
 }

--- a/source/Appccelerate.StateMachine/Machine/Reports/CsvStateMachineReportGenerator.cs
+++ b/source/Appccelerate.StateMachine/Machine/Reports/CsvStateMachineReportGenerator.cs
@@ -22,7 +22,6 @@ namespace Appccelerate.StateMachine.Machine.Reports
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-    using Infrastructure;
     using Machine;
     using States;
 
@@ -56,7 +55,7 @@ namespace Appccelerate.StateMachine.Machine.Reports
         /// <param name="name">The name of the state machine.</param>
         /// <param name="states">The states.</param>
         /// <param name="initialStateId">The initial state id.</param>
-        public void Report(string name, IEnumerable<IStateDefinition<TState, TEvent>> states, Initializable<TState> initialStateId)
+        public void Report(string name, IEnumerable<IStateDefinition<TState, TEvent>> states, TState initialStateId)
         {
             states = states.ToList();
 

--- a/source/Appccelerate.StateMachine/Machine/Reports/StateMachineReportGenerator.cs
+++ b/source/Appccelerate.StateMachine/Machine/Reports/StateMachineReportGenerator.cs
@@ -23,7 +23,6 @@ namespace Appccelerate.StateMachine.Machine.Reports
     using System.Globalization;
     using System.Linq;
     using System.Text;
-    using Infrastructure;
     using Machine;
     using States;
     using Transitions;
@@ -49,18 +48,17 @@ namespace Appccelerate.StateMachine.Machine.Reports
         /// <param name="name">The name of the state machine.</param>
         /// <param name="states">The states.</param>
         /// <param name="initialStateId">The initial state id.</param>
-        public void Report(string name, IEnumerable<IStateDefinition<TState, TEvent>> states, Initializable<TState> initialStateId)
+        public void Report(string name, IEnumerable<IStateDefinition<TState, TEvent>> states, TState initialStateId)
         {
             states = states.ToList();
 
             Guard.AgainstNullArgument("states", states);
-            Guard.AgainstNullArgument("initialStateId", initialStateId);
 
             var report = new StringBuilder();
 
             const string indentation = "    ";
 
-            report.AppendFormat("{0}: initial state = {1}{2}", name, initialStateId.IsInitialized ? initialStateId.Value.ToString() : "none", Environment.NewLine);
+            report.AppendFormat("{0}: initial state = {1}{2}", name, initialStateId.ToString(), Environment.NewLine);
 
             // write states
             var rootStates = states.Where(state => state.SuperState == null);

--- a/source/Appccelerate.StateMachine/Machine/Reports/YEdStateMachineReportGenerator.cs
+++ b/source/Appccelerate.StateMachine/Machine/Reports/YEdStateMachineReportGenerator.cs
@@ -243,7 +243,7 @@ namespace Appccelerate.StateMachine.Machine.Reports
 
         private bool DetermineWhetherThisIsAnInitialState(IStateDefinition<TState, TEvent> state)
         {
-            return (state.Id.ToString() == this.initialState.ToString())
+            return state.Id.ToString() == this.initialState.ToString()
                    || (state.SuperState != null && state.SuperState.InitialState == state);
         }
     }

--- a/source/Appccelerate.StateMachine/Machine/Reports/YEdStateMachineReportGenerator.cs
+++ b/source/Appccelerate.StateMachine/Machine/Reports/YEdStateMachineReportGenerator.cs
@@ -24,7 +24,6 @@ namespace Appccelerate.StateMachine.Machine.Reports
     using System.IO;
     using System.Linq;
     using System.Xml.Linq;
-    using Infrastructure;
     using Machine;
     using States;
     using Transitions;
@@ -49,7 +48,7 @@ namespace Appccelerate.StateMachine.Machine.Reports
 
         private int edgeId;
 
-        private Initializable<TState> initialStateId;
+        private TState initialState;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="YEdStateMachineReportGenerator&lt;TState, TEvent&gt;"/> class.
@@ -65,14 +64,14 @@ namespace Appccelerate.StateMachine.Machine.Reports
         /// </summary>
         /// <param name="name">The name of the state machine.</param>
         /// <param name="states">The states.</param>
-        /// <param name="initialState">The initial state id.</param>
-        public void Report(string name, IEnumerable<IStateDefinition<TState, TEvent>> states, Initializable<TState> initialState)
+        /// <param name="initialStateId">The initial state id.</param>
+        public void Report(string name, IEnumerable<IStateDefinition<TState, TEvent>> states, TState initialStateId)
         {
             var statesList = states.ToList();
 
             this.edgeId = 0;
 
-            this.initialStateId = initialState;
+            this.initialState = initialStateId;
             Guard.AgainstNullArgument("states", statesList);
 
             XElement graph = CreateGraph();
@@ -244,7 +243,8 @@ namespace Appccelerate.StateMachine.Machine.Reports
 
         private bool DetermineWhetherThisIsAnInitialState(IStateDefinition<TState, TEvent> state)
         {
-            return (this.initialStateId.IsInitialized && state.Id.ToString() == this.initialStateId.Value.ToString()) || (state.SuperState != null && state.SuperState.InitialState == state);
+            return (state.Id.ToString() == this.initialState.ToString())
+                   || (state.SuperState != null && state.SuperState.InitialState == state);
         }
     }
 }

--- a/source/Appccelerate.StateMachine/Machine/StateContainer.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateContainer.cs
@@ -47,9 +47,7 @@ namespace Appccelerate.StateMachine.Machine
 
         public List<IExtension<TState, TEvent>> Extensions { get; } = new List<IExtension<TState, TEvent>>();
 
-        public IInitializable<TState> CurrentStateIdNew => this.CurrentState.IsInitialized
-            ? new Initializable<TState> { Value = this.CurrentState.Value.Id }
-            : new Initializable<TState>();
+        public IInitializable<TState> CurrentStateIdNew => this.CurrentState.Map(x => x.Id);
 
         public Initializable<IStateDefinition<TState, TEvent>> CurrentState { get; set; }
 

--- a/source/Appccelerate.StateMachine/Machine/StateContainer.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateContainer.cs
@@ -47,11 +47,9 @@ namespace Appccelerate.StateMachine.Machine
 
         public List<IExtension<TState, TEvent>> Extensions { get; } = new List<IExtension<TState, TEvent>>();
 
-        public IInitializable<TState> CurrentStateIdNew => this.CurrentState.Map(x => x.Id);
-
         public Initializable<IStateDefinition<TState, TEvent>> CurrentState { get; set; }
 
-        public TState CurrentStateId => throw new InvalidOperationException();
+        public IInitializable<TState> CurrentStateId => this.CurrentState.Map(x => x.Id);
 
         public IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> LastActiveStates => this.lastActiveStates;
 

--- a/source/Appccelerate.StateMachine/Machine/StateContainer.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateContainer.cs
@@ -40,17 +40,20 @@ namespace Appccelerate.StateMachine.Machine
         public StateContainer(string name)
         {
             this.Name = name;
+            this.CurrentState = Initializable<IStateDefinition<TState, TEvent>>.UnInitialized();
         }
 
         public string Name { get; }
 
         public List<IExtension<TState, TEvent>> Extensions { get; } = new List<IExtension<TState, TEvent>>();
 
-        public Initializable<TState> InitialStateId { get; } = new Initializable<TState>();
+        public IInitializable<TState> CurrentStateIdNew => this.CurrentState.IsInitialized
+            ? new Initializable<TState> { Value = this.CurrentState.Value.Id }
+            : new Initializable<TState>();
 
-        public IStateDefinition<TState, TEvent> CurrentState { get; set; }
+        public Initializable<IStateDefinition<TState, TEvent>> CurrentState { get; set; }
 
-        public TState CurrentStateId => this.CurrentState.Id;
+        public TState CurrentStateId => throw new InvalidOperationException();
 
         public IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> LastActiveStates => this.lastActiveStates;
 

--- a/source/Appccelerate.StateMachine/Machine/StateMachine.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateMachine.cs
@@ -78,7 +78,7 @@ namespace Appccelerate.StateMachine.Machine
         }
 
         /// <summary>
-        /// Enters the initial state as specified with <see cref="initialState"/>.
+        /// Enters the initial state as specified with <paramref name="initialState"/>.
         /// </summary>
         /// <param name="stateContainer">Contains all mutable state of of the state machine.</param>
         /// <param name="stateMachineInformation">The state machine information.</param>

--- a/source/Appccelerate.StateMachine/Machine/StateMachine.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateMachine.cs
@@ -20,6 +20,7 @@ namespace Appccelerate.StateMachine.Machine
 {
     using System;
     using Events;
+    using Infrastructure;
     using States;
 
     /// <summary>
@@ -68,48 +69,35 @@ namespace Appccelerate.StateMachine.Machine
 
         private static void SwitchStateTo(IStateDefinition<TState, TEvent> newState, StateContainer<TState, TEvent> stateContainer, IStateMachineInformation<TState, TEvent> stateMachineInformation)
         {
-            var oldState = stateContainer.CurrentState;
+            var oldState = stateContainer.CurrentState.IsInitialized
+                ? stateContainer.CurrentState.Value
+                : null;
 
-            stateContainer.CurrentState = newState;
+            stateContainer.CurrentState = Initializable<IStateDefinition<TState, TEvent>>.Initialized(newState);
 
             stateContainer.ForEach(extension =>
                 extension.SwitchedState(stateMachineInformation, oldState, newState));
         }
 
         /// <summary>
-        /// Initializes the state machine by setting the specified initial state.
-        /// </summary>
-        /// <param name="initialState">The initial state of the state machine.</param>
-        /// <param name="stateContainer">Contains all mutable state of of the state machine.</param>
-        /// <param name="stateMachineInformation">The state machine information.</param>
-        public void Initialize(TState initialState, StateContainer<TState, TEvent> stateContainer, IStateMachineInformation<TState, TEvent> stateMachineInformation)
-        {
-            stateContainer.ForEach(extension => extension.InitializingStateMachine(stateMachineInformation, ref initialState));
-
-            Initialize(initialState, stateContainer);
-
-            stateContainer.ForEach(extension => extension.InitializedStateMachine(stateMachineInformation, initialState));
-        }
-
-        /// <summary>
-        /// Enters the initial state that was previously set with <see cref="Initialize(TState, StateContainer{TState,TEvent}, IStateMachineInformation{TState,TEvent})"/>.
+        /// Enters the initial state as specified with <see cref="initialState"/>.
         /// </summary>
         /// <param name="stateContainer">Contains all mutable state of of the state machine.</param>
         /// <param name="stateMachineInformation">The state machine information.</param>
         /// <param name="stateDefinitions">The definitions for all states of this state Machine.</param>
+        /// <param name="initialState">The initial state the state machine should enter.</param>
         public void EnterInitialState(
             StateContainer<TState, TEvent> stateContainer,
             IStateMachineInformation<TState, TEvent> stateMachineInformation,
-            IStateDefinitionDictionary<TState, TEvent> stateDefinitions)
+            IStateDefinitionDictionary<TState, TEvent> stateDefinitions,
+            TState initialState)
         {
-            CheckThatStateMachineIsInitialized(stateContainer);
-
-            stateContainer.ForEach(extension => extension.EnteringInitialState(stateMachineInformation, stateContainer.InitialStateId.Value));
+            stateContainer.ForEach(extension => extension.EnteringInitialState(stateMachineInformation, initialState));
 
             var context = this.factory.CreateTransitionContext(null, new Missable<TEvent>(), Missing.Value, this);
-            this.EnterInitialState(context, stateContainer, stateMachineInformation, stateDefinitions);
+            this.EnterInitialState(context, stateContainer, stateMachineInformation, stateDefinitions, initialState);
 
-            stateContainer.ForEach(extension => extension.EnteredInitialState(stateMachineInformation, stateContainer.InitialStateId.Value, context));
+            stateContainer.ForEach(extension => extension.EnteredInitialState(stateMachineInformation, initialState, context));
         }
 
         /// <summary>
@@ -143,13 +131,12 @@ namespace Appccelerate.StateMachine.Machine
             IStateMachineInformation<TState, TEvent> stateMachineInformation,
             IStateDefinitionDictionary<TState, TEvent> stateDefinitions)
         {
-            CheckThatStateMachineIsInitialized(stateContainer);
             CheckThatStateMachineHasEnteredInitialState(stateContainer);
 
             stateContainer.ForEach(extension => extension.FiringEvent(stateMachineInformation, ref eventId, ref eventArgument));
 
-            var context = this.factory.CreateTransitionContext(stateContainer.CurrentState, new Missable<TEvent>(eventId), eventArgument, this);
-            var result = this.stateLogic.Fire(stateContainer.CurrentState, context, stateContainer);
+            var context = this.factory.CreateTransitionContext(stateContainer.CurrentState.Value, new Missable<TEvent>(eventId), eventArgument, this);
+            var result = this.stateLogic.Fire(stateContainer.CurrentState.Value, context, stateContainer);
 
             if (!result.Fired)
             {
@@ -210,34 +197,20 @@ namespace Appccelerate.StateMachine.Machine
             this.RaiseEvent(
                 this.TransitionCompleted,
                 new TransitionCompletedEventArgs<TState, TEvent>(
-                    stateMachineInformation.CurrentStateId,
+                    stateMachineInformation.CurrentStateIdNew.Value,
                     transitionContext),
                 transitionContext,
                 true);
-        }
-
-        /// <summary>
-        /// Initializes the state machine by setting the specified initial state.
-        /// </summary>
-        /// <param name="initialState">The initial state.</param>
-        /// <param name="stateContainer">Contains all mutable state of of the state machine.</param>
-        private static void Initialize(TState initialState, StateContainer<TState, TEvent> stateContainer)
-        {
-            if (stateContainer.InitialStateId.IsInitialized)
-            {
-                throw new InvalidOperationException(ExceptionMessages.StateMachineIsAlreadyInitialized);
-            }
-
-            stateContainer.InitialStateId.Value = initialState;
         }
 
         private void EnterInitialState(
             ITransitionContext<TState, TEvent> context,
             StateContainer<TState, TEvent> stateContainer,
             IStateMachineInformation<TState, TEvent> stateMachineInformation,
-            IStateDefinitionDictionary<TState, TEvent> stateDefinitions)
+            IStateDefinitionDictionary<TState, TEvent> stateDefinitions,
+            TState initialStateId)
         {
-            var initialState = stateDefinitions[stateContainer.InitialStateId.Value];
+            var initialState = stateDefinitions[initialStateId];
             var initializer = this.factory.CreateStateMachineInitializer(initialState, context);
             var newStateId = initializer.EnterInitialState(this.stateLogic, stateContainer);
             var newStateDefinition = stateDefinitions[newStateId];
@@ -267,17 +240,9 @@ namespace Appccelerate.StateMachine.Machine
             }
         }
 
-        private static void CheckThatStateMachineIsInitialized(StateContainer<TState, TEvent> stateContainer)
-        {
-            if (stateContainer.CurrentState == null && !stateContainer.InitialStateId.IsInitialized)
-            {
-                throw new InvalidOperationException(ExceptionMessages.StateMachineNotInitialized);
-            }
-        }
-
         private static void CheckThatStateMachineHasEnteredInitialState(StateContainer<TState, TEvent> stateContainer)
         {
-            if (stateContainer.CurrentState == null)
+            if (!stateContainer.CurrentState.IsInitialized)
             {
                 throw new InvalidOperationException(ExceptionMessages.StateMachineHasNotYetEnteredInitialState);
             }

--- a/source/Appccelerate.StateMachine/Machine/StateMachine.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateMachine.cs
@@ -196,7 +196,7 @@ namespace Appccelerate.StateMachine.Machine
             this.RaiseEvent(
                 this.TransitionCompleted,
                 new TransitionCompletedEventArgs<TState, TEvent>(
-                    stateMachineInformation.CurrentStateIdNew.ExtractOrThrow(),
+                    stateMachineInformation.CurrentStateId.ExtractOrThrow(),
                     transitionContext),
                 transitionContext,
                 true);

--- a/source/Appccelerate.StateMachine/Machine/StateMachineDefinition.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateMachineDefinition.cs
@@ -29,13 +29,16 @@ namespace Appccelerate.StateMachine.Machine
     {
         private readonly IStateDefinitionDictionary<TState, TEvent> stateDefinitions;
         private readonly IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates;
+        private readonly TState initialState;
 
         public StateMachineDefinition(
             IStateDefinitionDictionary<TState, TEvent> stateDefinitions,
-            IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates)
+            IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates,
+            TState initialState)
         {
             this.stateDefinitions = stateDefinitions;
             this.initiallyLastActiveStates = initiallyLastActiveStates;
+            this.initialState = initialState;
         }
 
         public PassiveStateMachine<TState, TEvent> CreatePassiveStateMachine()
@@ -59,7 +62,7 @@ namespace Appccelerate.StateMachine.Machine
             var standardFactory = new StandardFactory<TState, TEvent>();
             var stateMachine = new StateMachine<TState, TEvent>(standardFactory, stateLogic);
 
-            return new PassiveStateMachine<TState, TEvent>(stateMachine, stateContainer, this.stateDefinitions);
+            return new PassiveStateMachine<TState, TEvent>(stateMachine, stateContainer, this.stateDefinitions, this.initialState);
         }
 
         public ActiveStateMachine<TState, TEvent> CreateActiveStateMachine()
@@ -83,7 +86,7 @@ namespace Appccelerate.StateMachine.Machine
             var standardFactory = new StandardFactory<TState, TEvent>();
             var stateMachine = new StateMachine<TState, TEvent>(standardFactory, stateLogic);
 
-            return new ActiveStateMachine<TState, TEvent>(stateMachine, stateContainer, this.stateDefinitions);
+            return new ActiveStateMachine<TState, TEvent>(stateMachine, stateContainer, this.stateDefinitions, this.initialState);
         }
     }
 }

--- a/source/Appccelerate.StateMachine/Machine/StateMachineDefinitionBuilder.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateMachineDefinitionBuilder.cs
@@ -30,6 +30,8 @@ namespace Appccelerate.StateMachine.Machine
         private readonly StandardFactory<TState, TEvent> factory = new StandardFactory<TState, TEvent>();
         private readonly ImplicitAddIfNotAvailableStateDefinitionDictionary<TState, TEvent> stateDefinitionDictionary = new ImplicitAddIfNotAvailableStateDefinitionDictionary<TState, TEvent>();
         private readonly Dictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates = new Dictionary<TState, IStateDefinition<TState, TEvent>>();
+        private TState initialState;
+        private bool isInitialStateConfigured;
 
         public IEntryActionSyntax<TState, TEvent> In(TState state)
         {
@@ -41,10 +43,22 @@ namespace Appccelerate.StateMachine.Machine
             return new HierarchyBuilder<TState, TEvent>(superStateId, this.stateDefinitionDictionary, this.initiallyLastActiveStates);
         }
 
+        public StateMachineDefinitionBuilder<TState, TEvent> WithInitialState(TState initialStateToUse)
+        {
+            this.initialState = initialStateToUse;
+            this.isInitialStateConfigured = true;
+            return this;
+        }
+
         public StateMachineDefinition<TState, TEvent> Build()
         {
+            if (!this.isInitialStateConfigured)
+            {
+                throw new InvalidOperationException(ExceptionMessages.InitialStateNotConfigured);
+            }
+
             var stateDefinitions = new StateDefinitionDictionary<TState, TEvent>(this.stateDefinitionDictionary.ReadOnlyDictionary);
-            return new StateMachineDefinition<TState, TEvent>(stateDefinitions, this.initiallyLastActiveStates);
+            return new StateMachineDefinition<TState, TEvent>(stateDefinitions, this.initiallyLastActiveStates, this.initialState);
         }
     }
 }

--- a/source/Appccelerate.StateMachine/PassiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/PassiveStateMachine.cs
@@ -164,14 +164,6 @@ namespace Appccelerate.StateMachine
         }
 
         /// <summary>
-        /// Initializes the state machine to the specified initial state.
-        /// </summary>
-        /// <param name="initialState">The state to which the state machine is initialized.</param>
-        public void Initialize(TState initialState)
-        {
-        }
-
-        /// <summary>
         /// Starts the state machine. Events will be processed.
         /// If the state machine is not started then the events will be queued until the state machine is started.
         /// Already queued events are processed.

--- a/source/Appccelerate.StateMachine/PassiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/PassiveStateMachine.cs
@@ -21,10 +21,8 @@ namespace Appccelerate.StateMachine
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using Infrastructure;
     using Machine;
     using Machine.Events;
-    using Machine.States;
     using Persistence;
 
     /// <summary>
@@ -232,7 +230,7 @@ namespace Appccelerate.StateMachine
         {
             Guard.AgainstNullArgument(nameof(stateMachineSaver), stateMachineSaver);
 
-            stateMachineSaver.SaveCurrentState(this.stateContainer.CurrentStateIdNew);
+            stateMachineSaver.SaveCurrentState(this.stateContainer.CurrentStateId);
 
             var historyStates = this.stateContainer
                 .LastActiveStates

--- a/source/Appccelerate.StateMachine/PassiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/PassiveStateMachine.cs
@@ -263,16 +263,7 @@ namespace Appccelerate.StateMachine
 
             void SetCurrentState()
             {
-                if (loadedCurrentState.IsInitialized)
-                {
-                    this.stateContainer.CurrentState =
-                        Initializable<IStateDefinition<TState, TEvent>>.Initialized(
-                            this.stateDefinitions[loadedCurrentState.Value]);
-                }
-                else
-                {
-                    this.stateContainer.CurrentState = Initializable<IStateDefinition<TState, TEvent>>.UnInitialized();
-                }
+                this.stateContainer.CurrentState = loadedCurrentState.Map(x => this.stateDefinitions[x]);
             }
 
             void LoadHistoryStates()

--- a/source/Appccelerate.StateMachine/PassiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/PassiveStateMachine.cs
@@ -277,8 +277,10 @@ namespace Appccelerate.StateMachine
                         Initializable<IStateDefinition<TState, TEvent>>.Initialized(
                             this.stateDefinitions[loadedCurrentState.Value]);
                 }
-
-                this.stateContainer.CurrentState = Initializable<IStateDefinition<TState, TEvent>>.UnInitialized();
+                else
+                {
+                    this.stateContainer.CurrentState = Initializable<IStateDefinition<TState, TEvent>>.UnInitialized();
+                }
             }
 
             void LoadHistoryStates()

--- a/source/Appccelerate.StateMachine/Persistence/IAsyncStateMachineLoader.cs
+++ b/source/Appccelerate.StateMachine/Persistence/IAsyncStateMachineLoader.cs
@@ -30,7 +30,7 @@ namespace Appccelerate.StateMachine.Persistence
         /// Returns the state to be set as the current state of the state machine.
         /// </summary>
         /// <returns>State id.</returns>
-        Task<Initializable<TState>> LoadCurrentState();
+        Task<IInitializable<TState>> LoadCurrentState();
 
         /// <summary>
         /// Returns the last active state of all super states that have a last active state (i.e. they count as visited).

--- a/source/Appccelerate.StateMachine/Persistence/IAsyncStateMachineSaver.cs
+++ b/source/Appccelerate.StateMachine/Persistence/IAsyncStateMachineSaver.cs
@@ -31,7 +31,7 @@ namespace Appccelerate.StateMachine.Persistence
         /// </summary>
         /// <param name="currentStateId">Id of the current state.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task SaveCurrentState(Initializable<TState> currentStateId);
+        Task SaveCurrentState(IInitializable<TState> currentStateId);
 
         /// <summary>
         /// Saves the last active states of all super states.

--- a/source/Appccelerate.StateMachine/Persistence/IStateMachineLoader.cs
+++ b/source/Appccelerate.StateMachine/Persistence/IStateMachineLoader.cs
@@ -29,7 +29,7 @@ namespace Appccelerate.StateMachine.Persistence
         /// Returns the state to be set as the current state of the state machine.
         /// </summary>
         /// <returns>State id.</returns>
-        Initializable<TState> LoadCurrentState();
+        IInitializable<TState> LoadCurrentState();
 
         /// <summary>
         /// Returns the last active state of all super states that have a last active state (i.e. they count as visited).

--- a/source/Appccelerate.StateMachine/Persistence/IStateMachineSaver.cs
+++ b/source/Appccelerate.StateMachine/Persistence/IStateMachineSaver.cs
@@ -29,7 +29,7 @@ namespace Appccelerate.StateMachine.Persistence
         /// Saves the current state of the state machine.
         /// </summary>
         /// <param name="currentStateId">Id of the current state.</param>
-        void SaveCurrentState(Initializable<TState> currentStateId);
+        void SaveCurrentState(IInitializable<TState> currentStateId);
 
         /// <summary>
         /// Saves the last active states of all super states.


### PR DESCRIPTION
Previously to initialize an Active/Passive SM the method ```Initialize(TState initialState)``` had to be called. The SM would then remember this initial State but NOT yet transition to it. The transition would only be done once ```Start()``` was called.

After this change, the initalState will already have to be configured at definition time via ```StateMachineDefinitionBuilder.WithInitialState(TState initialStateToUse)```.
The SM will no longer need an Initialize method.
Same as before this change, the transition to the initial state would only be done once ```Start()``` was called.