### PR TITLE
Feature/move all state to state container

### DIFF
--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/ExceptionCasesFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/ExceptionCasesFacts.cs
@@ -21,8 +21,8 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
     using System;
     using System.Threading.Tasks;
     using FluentAssertions;
-    using Infrastructure;
     using StateMachine.AsyncMachine;
+    using StateMachine.Infrastructure;
     using Xunit;
 
     public class ExceptionCasesFacts

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/ExceptionCasesFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/ExceptionCasesFacts.cs
@@ -38,7 +38,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .Build();
 
             Func<Task> action = async () =>
-                await testee.Fire(Events.A, Missing.Value, stateContainer, stateContainer, stateDefinitions)
+                await testee.Fire(Events.A, Missing.Value, stateContainer, stateDefinitions)
                     .ConfigureAwait(false);
             action.Should().Throw<InvalidOperationException>();
         }
@@ -78,10 +78,10 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
 
             testee.TransitionExceptionThrown += (sender, eventArgs) => { };
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
-            await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
+            await testee.Fire(Events.B, eventArguments, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             stateContainer
@@ -114,10 +114,10 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
             testee.TransitionDeclined += (sender, e) => transitionDeclined = true;
             testee.TransitionExceptionThrown += (sender, eventArgs) => { };
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
-            await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
+            await testee.Fire(Events.B, eventArguments, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             transitionDeclined
@@ -155,10 +155,10 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                     eventArgs.Exception);
             };
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
-            await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
+            await testee.Fire(Events.B, eventArguments, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             capturedException
@@ -189,10 +189,10 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
 
             testee.TransitionExceptionThrown += (sender, eventArgs) => { };
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
-            await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
+            await testee.Fire(Events.B, eventArguments, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             stateContainer
@@ -228,10 +228,10 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                     eventArgs.Exception);
             };
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
-            await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
+            await testee.Fire(Events.B, eventArguments, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             capturedException
@@ -258,10 +258,10 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
 
             testee.TransitionExceptionThrown += (sender, eventArgs) => { };
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
-            await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
+            await testee.Fire(Events.B, eventArguments, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             stateContainer
@@ -300,10 +300,10 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                     eventArgs.Exception);
             };
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
-            await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
+            await testee.Fire(Events.B, eventArguments, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             capturedException
@@ -333,10 +333,10 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
 
             testee.TransitionExceptionThrown += (sender, eventArgs) => { };
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
-            await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
+            await testee.Fire(Events.B, eventArguments, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             stateContainer
@@ -373,10 +373,10 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                     eventArgs.Exception);
             };
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
-            await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
+            await testee.Fire(Events.B, eventArguments, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             capturedException
@@ -404,10 +404,10 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
 
             testee.TransitionExceptionThrown += (sender, eventArgs) => { };
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
-            await testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions)
+            await testee.Fire(Events.B, eventArguments, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             stateContainer
@@ -427,7 +427,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .Build();
 
             Func<Task> action = async () =>
-                await testee.Fire(Events.B, Missing.Value, stateContainer, stateContainer, stateDefinitions)
+                await testee.Fire(Events.B, Missing.Value, stateContainer, stateDefinitions)
                     .ConfigureAwait(false);
             action.Should().Throw<InvalidOperationException>();
         }

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/GuardFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/GuardFacts.cs
@@ -50,10 +50,10 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
-            await testee.Fire(Events.A, ExpectedEventArgument, stateContainer, stateContainer, stateDefinitions)
+            await testee.Fire(Events.A, ExpectedEventArgument, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             actualEventArgument
@@ -84,10 +84,10 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
-            await testee.Fire(Events.A, ExpectedEventArgument, stateContainer, stateContainer, stateDefinitions)
+            await testee.Fire(Events.A, ExpectedEventArgument, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             actualEventArgument
@@ -111,10 +111,10 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
-            await testee.Fire(Events.B, Missing.Value, stateContainer, stateContainer, stateDefinitions)
+            await testee.Fire(Events.B, Missing.Value, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             stateContainer
@@ -141,10 +141,10 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
-            await testee.Fire(Events.B, 3, stateContainer, stateContainer, stateDefinitions)
+            await testee.Fire(Events.B, 3, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             stateContainer

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/GuardFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/GuardFacts.cs
@@ -21,8 +21,8 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
     using System;
     using System.Threading.Tasks;
     using FluentAssertions;
-    using Infrastructure;
     using StateMachine.AsyncMachine;
+    using StateMachine.Infrastructure;
     using Xunit;
 
     public class GuardFacts

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/HierarchyBuilderFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/HierarchyBuilderFacts.cs
@@ -32,14 +32,14 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
         private readonly HierarchyBuilder<string, int> testee;
         private readonly IImplicitAddIfNotAvailableStateDefinitionDictionary<string, int> states;
         private readonly StateDefinition<string, int> superState;
-        private readonly IDictionary<string, IStateDefinition<string, int>> initiallyLastActiveStates;
+        private readonly IDictionary<string, string> initiallyLastActiveStates;
 
         public HierarchyBuilderFacts()
         {
             this.superState = new StateDefinition<string, int>(SuperState);
             this.states = A.Fake<IImplicitAddIfNotAvailableStateDefinitionDictionary<string, int>>();
             A.CallTo(() => this.states[SuperState]).Returns(this.superState);
-            this.initiallyLastActiveStates = A.Fake<IDictionary<string, IStateDefinition<string, int>>>();
+            this.initiallyLastActiveStates = A.Fake<IDictionary<string, string>>();
 
             this.testee = new HierarchyBuilder<string, int>(SuperState, this.states, this.initiallyLastActiveStates);
         }
@@ -84,7 +84,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
 
             this.testee.WithInitialSubState(SubState);
 
-            A.CallTo(() => this.initiallyLastActiveStates.Add(SuperState, subState)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => this.initiallyLastActiveStates.Add(SuperState, SubState)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/StateActionFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/StateActionFacts.cs
@@ -41,7 +41,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             entered
@@ -67,7 +67,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             entered1.Should().BeTrue("entry action was not executed.");
@@ -92,7 +92,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
             receivedValue
@@ -117,10 +117,10 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
-            await testee.Fire(Events.B, null, stateContainer, stateContainer, stateDefinitions)
+            await testee.Fire(Events.B, null, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             exit
@@ -147,10 +147,10 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
-            await testee.Fire(Events.B, null, stateContainer, stateContainer, stateDefinitions)
+            await testee.Fire(Events.B, null, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             exit1.Should().BeTrue("exit action was not executed.");
@@ -176,10 +176,10 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            await testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A)
+            await testee.EnterInitialState(stateContainer, stateDefinitions, States.A)
                 .ConfigureAwait(false);
 
-            await testee.Fire(Events.B, null, stateContainer, stateContainer, stateDefinitions)
+            await testee.Fire(Events.B, null, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             receivedValue.Should().Be(Parameter);

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/StateContainerFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/StateContainerFacts.cs
@@ -61,7 +61,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
         public async Task ExtensionsWhenExtensionsAreClearedThenNoExtensionIsRegistered()
         {
             var executed = false;
-            var extension = A.Fake<IExtension<string, int>>();
+            var extension = A.Fake<IExtensionInternal<string, int>>();
 
             var testee = new StateContainer<string, int>();
 

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/StateContainerFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/StateContainerFacts.cs
@@ -22,7 +22,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
     using FakeItEasy;
     using FluentAssertions;
     using StateMachine.AsyncMachine;
-    using StateMachine.AsyncMachine.States;
+    using StateMachine.Infrastructure;
     using Xunit;
 
     public class StateContainerFacts
@@ -33,28 +33,36 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
             const string Name = "container";
             var stateContainer = new StateContainer<string, int>(Name);
 
-            stateContainer.Name.Should().Be(Name);
+            stateContainer
+                .Name
+                .Should()
+                .Be(Name);
         }
 
         [Fact]
-        public void ReturnsNullAsLastActiveStateWhenStateWasNeverSet()
+        public void ReturnsNothingAsLastActiveStateWhenStateWasNeverSet()
         {
-            var stateContainer = new StateContainer<string, int>("container");
+            var stateContainer = new StateContainer<string, int>();
 
-            stateContainer.SetLastActiveStateFor("A", A.Fake<IStateDefinition<string, int>>());
+            stateContainer.SetLastActiveStateFor("A", "helloWorld");
 
-            stateContainer.GetLastActiveStateOrNullFor("B").Should().BeNull();
+            stateContainer
+                .GetLastActiveStateFor("B")
+                .Should()
+                .BeEquivalentTo(Optional<string>.Nothing());
         }
 
         [Fact]
-        public void ReturnsStateDefinitionXAsLastActiveStateWhenStateDefinitionXWasSetBefore()
+        public void ReturnsStateXAsLastActiveStateWhenXWasSetBefore()
         {
-            var stateContainer = new StateContainer<string, int>("container");
-            var lastActiveState = A.Fake<IStateDefinition<string, int>>();
+            var stateContainer = new StateContainer<string, int>();
 
-            stateContainer.SetLastActiveStateFor("A", lastActiveState);
+            stateContainer.SetLastActiveStateFor("A", "Z");
 
-            stateContainer.GetLastActiveStateOrNullFor("A").Should().Be(lastActiveState);
+            stateContainer
+                .GetLastActiveStateFor("A")
+                .Should()
+                .BeEquivalentTo(Optional<string>.Just("Z"));
         }
 
         [Fact]

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/StateDefinitionsBuilder.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/StateDefinitionsBuilder.cs
@@ -22,7 +22,6 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
     using System.Collections.Generic;
     using AsyncSyntax;
     using StateMachine.AsyncMachine;
-    using StateMachine.AsyncMachine.States;
 
     public class StateDefinitionsBuilder<TState, TEvent>
         where TState : IComparable
@@ -30,7 +29,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
     {
         private readonly StandardFactory<TState, TEvent> factory = new StandardFactory<TState, TEvent>();
         private readonly ImplicitAddIfNotAvailableStateDefinitionDictionary<TState, TEvent> stateDefinitionDictionary = new ImplicitAddIfNotAvailableStateDefinitionDictionary<TState, TEvent>();
-        private readonly Dictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates = new Dictionary<TState, IStateDefinition<TState, TEvent>>();
+        private readonly Dictionary<TState, TState> initiallyLastActiveStates = new Dictionary<TState, TState>();
 
         public IEntryActionSyntax<TState, TEvent> In(TState state)
         {

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/StateMachineBuilder.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/StateMachineBuilder.cs
@@ -43,8 +43,8 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine
         public StateMachine<TState, TEvent> Build()
         {
             var factory = new StandardFactory<TState, TEvent>();
-            var transitionLogic = new TransitionLogic<TState, TEvent>(this.stateContainer, this.stateContainer);
-            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, this.stateContainer, this.stateContainer);
+            var transitionLogic = new TransitionLogic<TState, TEvent>(this.stateContainer);
+            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, this.stateContainer);
             transitionLogic.SetStateLogic(stateLogic);
 
             return new StateMachine<TState, TEvent>(factory, stateLogic);

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/ExceptionThrowingActionTransitionFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/ExceptionThrowingActionTransitionFacts.cs
@@ -48,14 +48,14 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task CallsExtensionToHandleException()
         {
-            var extension = A.Fake<IExtension<States, Events>>();
+            var extension = A.Fake<IExtensionInternal<States, Events>>();
 
             this.ExtensionHost.Extension = extension;
 
             await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
 
-            A.CallTo(() => extension.HandlingTransitionException(this.StateMachineInformation, this.TransitionDefinition, this.TransitionContext, ref this.exception)).MustHaveHappened();
-            A.CallTo(() => extension.HandledTransitionException(this.StateMachineInformation, this.TransitionDefinition, this.TransitionContext, this.exception)).MustHaveHappened();
+            A.CallTo(() => extension.HandlingTransitionException(this.TransitionDefinition, this.TransitionContext, ref this.exception)).MustHaveHappened();
+            A.CallTo(() => extension.HandledTransitionException(this.TransitionDefinition, this.TransitionContext, this.exception)).MustHaveHappened();
         }
 
         [Fact]

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/ExceptionThrowingActionTransitionFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/ExceptionThrowingActionTransitionFacts.cs
@@ -52,7 +52,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
 
             this.ExtensionHost.Extension = extension;
 
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => extension.HandlingTransitionException(this.TransitionDefinition, this.TransitionContext, ref this.exception)).MustHaveHappened();
             A.CallTo(() => extension.HandledTransitionException(this.TransitionDefinition, this.TransitionContext, this.exception)).MustHaveHappened();
@@ -61,7 +61,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task ReturnsFiredTransitionResult()
         {
-            var result = await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            var result = await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             result.Fired.Should().BeTrue();
         }
@@ -69,7 +69,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task NotifiesExceptionOnTransitionContext()
         {
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.TransitionContext.OnExceptionThrown(this.exception)).MustHaveHappened();
         }

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/ExceptionThrowingGuardTransitionFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/ExceptionThrowingGuardTransitionFacts.cs
@@ -48,14 +48,14 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task CallsExtensionToHandleException()
         {
-            var extension = A.Fake<IExtension<States, Events>>();
+            var extension = A.Fake<IExtensionInternal<States, Events>>();
 
             this.ExtensionHost.Extension = extension;
 
             await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
 
-            A.CallTo(() => extension.HandlingGuardException(this.StateMachineInformation, this.TransitionDefinition, this.TransitionContext, ref this.exception)).MustHaveHappened();
-            A.CallTo(() => extension.HandledGuardException(this.StateMachineInformation, this.TransitionDefinition, this.TransitionContext, this.exception)).MustHaveHappened();
+            A.CallTo(() => extension.HandlingGuardException(this.TransitionDefinition, this.TransitionContext, ref this.exception)).MustHaveHappened();
+            A.CallTo(() => extension.HandledGuardException(this.TransitionDefinition, this.TransitionContext, this.exception)).MustHaveHappened();
         }
 
         [Fact]

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/ExceptionThrowingGuardTransitionFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/ExceptionThrowingGuardTransitionFacts.cs
@@ -52,7 +52,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
 
             this.ExtensionHost.Extension = extension;
 
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => extension.HandlingGuardException(this.TransitionDefinition, this.TransitionContext, ref this.exception)).MustHaveHappened();
             A.CallTo(() => extension.HandledGuardException(this.TransitionDefinition, this.TransitionContext, this.exception)).MustHaveHappened();
@@ -61,7 +61,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task ReturnsNotFiredTransitionResult()
         {
-            var result = await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            var result = await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             result.Fired.Should().BeFalse();
         }
@@ -69,7 +69,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task NotifiesExceptionOnTransitionContext()
         {
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.TransitionContext.OnExceptionThrown(this.exception)).MustHaveHappened();
         }

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/GuardsTransitionFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/GuardsTransitionFacts.cs
@@ -74,7 +74,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task NotifiesExtensions_WhenGuardIsNotMet()
         {
-            var extension = A.Fake<IExtension<States, Events>>();
+            var extension = A.Fake<IExtensionInternal<States, Events>>();
             this.ExtensionHost.Extension = extension;
 
             var guard = Builder<States, Events>.CreateGuardHolder().ReturningFalse().Build();
@@ -83,7 +83,6 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
             await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
 
             A.CallTo(() => extension.SkippedTransition(
-                this.StateMachineInformation,
                 A<ITransitionDefinition<States, Events>>.That.Matches(t => t.Source == this.Source && t.Target == this.Target),
                 this.TransitionContext)).MustHaveHappened();
         }

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/GuardsTransitionFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/GuardsTransitionFacts.cs
@@ -44,7 +44,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
             var guard = Builder<States, Events>.CreateGuardHolder().ReturningTrue().Build();
             this.TransitionDefinition.Guard = guard;
 
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.Target, this.TransitionContext)).MustHaveHappenedOnceExactly();
         }
@@ -55,7 +55,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
             var guard = Builder<States, Events>.CreateGuardHolder().ReturningFalse().Build();
             this.TransitionDefinition.Guard = guard;
 
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.Target, this.TransitionContext)).MustNotHaveHappened();
         }
@@ -66,7 +66,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
             var guard = Builder<States, Events>.CreateGuardHolder().ReturningFalse().Build();
             this.TransitionDefinition.Guard = guard;
 
-            var result = await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            var result = await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             result.Should().BeNotFiredTransitionResult<States>();
         }
@@ -80,7 +80,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
             var guard = Builder<States, Events>.CreateGuardHolder().ReturningFalse().Build();
             this.TransitionDefinition.Guard = guard;
 
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => extension.SkippedTransition(
                 A<ITransitionDefinition<States, Events>>.That.Matches(t => t.Source == this.Source && t.Target == this.Target),

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/HierarchicalTransitionFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/HierarchicalTransitionFacts.cs
@@ -47,7 +47,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task ExitsStatesUpToBelowCommonSuperState()
         {
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Exit(this.Source, this.TransitionContext, this.LastActiveStateModifier)).MustHaveHappened()
                 .Then(A.CallTo(() => this.StateLogic.Exit(this.superStateOfSource, this.TransitionContext, this.LastActiveStateModifier)).MustHaveHappened());
@@ -56,7 +56,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task EntersStatesBelowCommonSuperStateToTarget()
         {
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.superStateOfTarget, this.TransitionContext)).MustHaveHappened()
                 .Then(A.CallTo(() => this.StateLogic.Entry(this.Target, this.TransitionContext)).MustHaveHappened());
@@ -65,7 +65,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task DoesNotExitCommonSuperState()
         {
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Exit(this.root, this.TransitionContext, this.LastActiveStateModifier)).MustNotHaveHappened();
         }
@@ -73,7 +73,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task DoesNotEnterCommonSuperState()
         {
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.root, this.TransitionContext)).MustNotHaveHappened();
         }

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/InternalTransitionFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/InternalTransitionFacts.cs
@@ -38,7 +38,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task DoesNotExitState()
         {
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Exit(this.Source, this.TransitionContext, this.LastActiveStateModifier)).MustNotHaveHappened();
         }
@@ -46,7 +46,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task DoesNotEnterState()
         {
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.Source, this.TransitionContext)).MustNotHaveHappened();
         }

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/SelfTransitionFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/SelfTransitionFacts.cs
@@ -38,7 +38,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task ExitsState()
         {
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Exit(this.Source, this.TransitionContext, this.LastActiveStateModifier)).MustHaveHappened();
         }
@@ -46,7 +46,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task EntersState()
         {
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.Target, this.TransitionContext)).MustHaveHappened();
         }

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/SourceIsDescendantOfTargetTransitionFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/SourceIsDescendantOfTargetTransitionFacts.cs
@@ -42,7 +42,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task ExitsOfAllStatesFromSourceUpToTarget()
         {
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Exit(this.Source, this.TransitionContext, this.LastActiveStateModifier)).MustHaveHappened()
                 .Then(A.CallTo(() => this.StateLogic.Exit(this.intermediate, this.TransitionContext, this.LastActiveStateModifier)).MustHaveHappened())
@@ -52,7 +52,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task EntersTargetState()
         {
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.Target, this.TransitionContext)).MustHaveHappened();
         }

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/SourceIsParentOfTargetTransitionFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/SourceIsParentOfTargetTransitionFacts.cs
@@ -42,7 +42,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task EntersAllStatesBelowSourceDownToTarget()
         {
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.intermediate, this.TransitionContext)).MustHaveHappened()
                 .Then(A.CallTo(() => this.StateLogic.Entry(this.Target, this.TransitionContext)).MustHaveHappened());

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/SuccessfulTransitionWithExecutedActionsFactsBase.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/SuccessfulTransitionWithExecutedActionsFactsBase.cs
@@ -59,22 +59,20 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
             await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
 
             extension.Items.Should().Contain(new FakeExtension.Item(
-                this.StateMachineInformation,
                 this.Source,
                 this.Target,
                 this.TransitionContext));
         }
 
-        public class FakeExtension : AsyncExtensionBase<States, Events>
+        public class FakeExtension : InternalExtensionBase<States, Events>
         {
             private readonly List<Item> items = new List<Item>();
 
             public override Task ExecutedTransition(
-                IStateMachineInformation<States, Events> stateMachine,
                 ITransitionDefinition<States, Events> transition,
                 ITransitionContext<States, Events> transitionContext)
             {
-                this.items.Add(new Item(stateMachine, transition.Source, transition.Target, transitionContext));
+                this.items.Add(new Item(transition.Source, transition.Target, transitionContext));
 
                 return Task.CompletedTask;
             }
@@ -86,7 +84,6 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
                 private bool Equals(Item other)
                 {
                     return
-                        Equals(this.StateMachine, other.StateMachine) &&
                         Equals(this.Source, other.Source) &&
                         (Equals(this.Target, other.Target) || (this.Target == null && other.Target == other.Source)) && // in case of an internal-transition, this.Target (from TransitionContext) is null (wherease it would be == this.Source in case of an self-transition) therefor we check the we did not switch state in this case
                         Equals(this.TransitionContext, other.TransitionContext);
@@ -116,8 +113,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
                 {
                     unchecked
                     {
-                        var hashCode = this.StateMachine != null ? this.StateMachine.GetHashCode() : 0;
-                        hashCode = (hashCode * 397) ^ (this.Source != null ? this.Source.GetHashCode() : 0);
+                        var hashCode = this.Source != null ? this.Source.GetHashCode() : 0;
                         hashCode = (hashCode * 397) ^ (this.Target != null ? this.Target.GetHashCode() : 0);
                         hashCode = (hashCode * 397) ^ (this.TransitionContext != null ? this.TransitionContext.GetHashCode() : 0);
                         return hashCode;
@@ -125,18 +121,14 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
                 }
 
                 public Item(
-                    IStateMachineInformation<States, Events> stateMachine,
                     IStateDefinition<States, Events> source,
                     IStateDefinition<States, Events> target,
                     ITransitionContext<States, Events> transitionContext)
                 {
-                    this.StateMachine = stateMachine;
                     this.Source = source;
                     this.Target = target;
                     this.TransitionContext = transitionContext;
                 }
-
-                public IStateMachineInformation<States, Events> StateMachine { get; }
 
                 public IStateDefinition<States, Events> Source { get; }
 

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/SuccessfulTransitionWithExecutedActionsFactsBase.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/SuccessfulTransitionWithExecutedActionsFactsBase.cs
@@ -33,7 +33,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task ReturnsSuccessfulTransitionResult()
         {
-            var result = await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            var result = await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             result.Should().BeSuccessfulTransitionResultWithNewState(this.Target);
         }
@@ -45,7 +45,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
 
             this.TransitionDefinition.ActionsModifiable.Add(new ArgumentLessActionHolder(() => executed = true));
 
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             executed.Should().BeTrue("actions should be executed");
         }
@@ -56,7 +56,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
             var extension = new FakeExtension();
             this.ExtensionHost.Extension = extension;
 
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             extension.Items.Should().Contain(new FakeExtension.Item(
                 this.Source,

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/TransitionDefinedInSuperStateTransitionFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/TransitionDefinedInSuperStateTransitionFacts.cs
@@ -44,7 +44,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task ExitsAllStatesFromCurrentUpToSource()
         {
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Exit(this.current, this.TransitionContext, this.LastActiveStateModifier)).MustHaveHappened()
                 .Then(A.CallTo(() => this.StateLogic.Exit(this.intermediate, this.TransitionContext, this.LastActiveStateModifier)).MustHaveHappened())

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/TransitionFacts.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/TransitionFacts.cs
@@ -38,7 +38,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task EntersDestinationState()
         {
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.Target, this.TransitionContext)).MustHaveHappenedOnceExactly();
         }
@@ -46,7 +46,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task ExitsSourceState()
         {
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Exit(this.Source, this.TransitionContext, this.LastActiveStateModifier)).MustHaveHappenedOnceExactly();
         }
@@ -54,7 +54,7 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         [Fact]
         public async Task NotifiesTransitionBeginOnTransitionContext()
         {
-            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            await this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.TransitionContext.OnTransitionBegin()).MustHaveHappened();
         }

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/TransitionFactsBase.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/TransitionFactsBase.cs
@@ -41,9 +41,11 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
 
         protected IStateLogic<States, Events> StateLogic { get; }
 
-        protected ILastActiveStateModifier<States, Events> LastActiveStateModifier { get; }
+        protected ILastActiveStateModifier<States> LastActiveStateModifier { get; }
 
         protected TestableExtensionHost ExtensionHost { get; }
+
+        protected IStateDefinitionDictionary<States, Events> StateDefinitions { get; }
 
         protected IStateDefinition<States, Events> Source { get; set; }
 
@@ -54,7 +56,8 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         protected TransitionFactsBase()
         {
             this.StateLogic = A.Fake<IStateLogic<States, Events>>();
-            this.LastActiveStateModifier = A.Fake<ILastActiveStateModifier<States, Events>>();
+            this.LastActiveStateModifier = A.Fake<ILastActiveStateModifier<States>>();
+            this.StateDefinitions = A.Fake<IStateDefinitionDictionary<States, Events>>();
             this.ExtensionHost = new TestableExtensionHost();
             this.TransitionDefinition = new TransitionDefinition<States, Events>();
 

--- a/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/TransitionFactsBase.cs
+++ b/source/Appccelerate.StateMachine.Facts/AsyncMachine/Transitions/TransitionFactsBase.cs
@@ -45,8 +45,6 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
 
         protected TestableExtensionHost ExtensionHost { get; }
 
-        protected IStateMachineInformation<States, Events> StateMachineInformation { get; }
-
         protected IStateDefinition<States, Events> Source { get; set; }
 
         protected IStateDefinition<States, Events> Target { get; set; }
@@ -57,19 +55,18 @@ namespace Appccelerate.StateMachine.Facts.AsyncMachine.Transitions
         {
             this.StateLogic = A.Fake<IStateLogic<States, Events>>();
             this.LastActiveStateModifier = A.Fake<ILastActiveStateModifier<States, Events>>();
-            this.StateMachineInformation = A.Fake<IStateMachineInformation<States, Events>>();
             this.ExtensionHost = new TestableExtensionHost();
             this.TransitionDefinition = new TransitionDefinition<States, Events>();
 
-            this.Testee = new TransitionLogic<States, Events>(this.ExtensionHost, this.StateMachineInformation);
+            this.Testee = new TransitionLogic<States, Events>(this.ExtensionHost);
             this.Testee.SetStateLogic(this.StateLogic);
         }
 
         protected class TestableExtensionHost : IExtensionHost<States, Events>
         {
-            public IExtension<States, Events> Extension { private get; set; }
+            public IExtensionInternal<States, Events> Extension { private get; set; }
 
-            public async Task ForEach(Func<IExtension<States, Events>, Task> action)
+            public async Task ForEach(Func<IExtensionInternal<States, Events>, Task> action)
             {
                 if (this.Extension != null)
                 {

--- a/source/Appccelerate.StateMachine.Facts/Infrastructure/InitializableTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Infrastructure/InitializableTest.cs
@@ -1,0 +1,99 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="InitializableTest.cs" company="Appccelerate">
+//   Copyright (c) 2008-2019 Appccelerate
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+namespace Appccelerate.StateMachine.Facts.Infrastructure
+{
+    using System;
+    using FluentAssertions;
+    using StateMachine.Infrastructure;
+    using StateMachine.Machine;
+    using Xunit;
+
+    public class InitializableTest
+    {
+        [Fact]
+        public void IsInitialized()
+        {
+            Initializable<SomeClass>
+                .Initialized(new SomeClass())
+                .IsInitialized
+                .Should()
+                .BeTrue();
+
+            Initializable<SomeClass>
+                .UnInitialized()
+                .IsInitialized
+                .Should()
+                .BeFalse();
+        }
+
+        [Fact]
+        public void ExtractOr()
+        {
+            Initializable<string>
+                .Initialized("A")
+                .ExtractOr("B")
+                .Should()
+                .Be("A");
+
+            Initializable<string>
+                .UnInitialized()
+                .ExtractOr("B")
+                .Should()
+                .Be("B");
+        }
+
+        [Fact]
+        public void ExtractOrThrow()
+        {
+            Initializable<string>
+                .Initialized("A")
+                .ExtractOrThrow()
+                .Should()
+                .Be("A");
+
+            Initializable<string>
+                .UnInitialized()
+                .Invoking(x => x.ExtractOrThrow())
+                .Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage(ExceptionMessages.ValueNotInitialized);
+        }
+
+        [Fact]
+        public void Map()
+        {
+            Initializable<SomeClass>
+                .Initialized(new SomeClass { SomeValue = "A" })
+                .Map(x => x.SomeValue)
+                .Should()
+                .BeEquivalentTo(Initializable<string>.Initialized("A"));
+
+            Initializable<SomeClass>
+                .UnInitialized()
+                .Map(x => x.SomeValue)
+                .Should()
+                .BeEquivalentTo(Initializable<string>.UnInitialized());
+        }
+
+        private class SomeClass
+        {
+            public string SomeValue { get; set; }
+        }
+    }
+}

--- a/source/Appccelerate.StateMachine.Facts/Machine/ActivePassiveStateMachineTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/ActivePassiveStateMachineTest.cs
@@ -24,8 +24,8 @@ namespace Appccelerate.StateMachine.Facts.Machine
     using System.Threading;
     using FakeItEasy;
     using FluentAssertions;
-    using Infrastructure;
     using Persistence;
+    using StateMachine.Infrastructure;
     using StateMachine.Machine;
     using StateMachine.Machine.Events;
     using Xunit;

--- a/source/Appccelerate.StateMachine.Facts/Machine/ActivePassiveStateMachineTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/ActivePassiveStateMachineTest.cs
@@ -374,6 +374,8 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 {
                     { States.D, States.D2 }
                 });
+            A.CallTo(() => loader.LoadCurrentState())
+                .Returns(Initializable<States>.UnInitialized());
 
             testee.Load(loader);
             testee.Start();

--- a/source/Appccelerate.StateMachine.Facts/Machine/ExceptionCasesTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/ExceptionCasesTest.cs
@@ -21,7 +21,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
     using System;
     using Appccelerate.StateMachine.Machine;
     using FluentAssertions;
-    using Infrastructure;
+    using StateMachine.Infrastructure;
     using Xunit;
 
     /// <summary>

--- a/source/Appccelerate.StateMachine.Facts/Machine/ExceptionCasesTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/ExceptionCasesTest.cs
@@ -96,9 +96,9 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 recordedException = eventArgs.Exception;
             };
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
-            testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions);
+            testee.Fire(Events.B, eventArguments, stateContainer, stateDefinitions);
 
             recordedStateId.Should().Be(States.A);
             recordedEventId.Should().Be(Events.B);
@@ -144,9 +144,9 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 recordedException = eventArgs.Exception;
             };
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
-            testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions);
+            testee.Fire(Events.B, eventArguments, stateContainer, stateDefinitions);
 
             recordedStateId.Should().Be(States.A);
             recordedEventId.Should().Be(Events.B);
@@ -189,9 +189,9 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 recordedException = eventArgs.Exception;
             };
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
-            testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions);
+            testee.Fire(Events.B, eventArguments, stateContainer, stateDefinitions);
 
             recordedStateId.Should().Be(States.A);
             recordedEventId.Should().Be(Events.B);
@@ -232,9 +232,9 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 recordedException = eventArgs.Exception;
             };
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
-            testee.Fire(Events.B, eventArguments, stateContainer, stateContainer, stateDefinitions);
+            testee.Fire(Events.B, eventArguments, stateContainer, stateDefinitions);
             recordedStateId.Should().Be(States.A);
             recordedEventId.Should().Be(Events.B);
             recordedEventArgument.Should().Be(eventArguments);

--- a/source/Appccelerate.StateMachine.Facts/Machine/GuardTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/GuardTest.cs
@@ -52,9 +52,9 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
-            testee.Fire(Events.A, EventArgument, stateContainer, stateContainer, stateDefinitions);
+            testee.Fire(Events.A, EventArgument, stateContainer, stateDefinitions);
 
             actualEventArgument.Should().Be(EventArgument);
         }
@@ -77,7 +77,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, stateContainer, stateContainer, stateDefinitions);
 
@@ -106,9 +106,9 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
-            testee.Fire(Events.B, 3, stateContainer, stateContainer, stateDefinitions);
+            testee.Fire(Events.B, 3, stateContainer, stateDefinitions);
 
             stateContainer
                 .CurrentStateId

--- a/source/Appccelerate.StateMachine.Facts/Machine/GuardTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/GuardTest.cs
@@ -19,7 +19,7 @@
 namespace Appccelerate.StateMachine.Facts.Machine
 {
     using FluentAssertions;
-    using Infrastructure;
+    using StateMachine.Infrastructure;
     using StateMachine.Machine;
     using Xunit;
 

--- a/source/Appccelerate.StateMachine.Facts/Machine/HierarchyBuilderTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/HierarchyBuilderTest.cs
@@ -32,14 +32,14 @@ namespace Appccelerate.StateMachine.Facts.Machine
         private readonly HierarchyBuilder<string, int> testee;
         private readonly IImplicitAddIfNotAvailableStateDefinitionDictionary<string, int> states;
         private readonly StateDefinition<string, int> superState;
-        private readonly IDictionary<string, IStateDefinition<string, int>> initiallyLastActiveStates;
+        private readonly IDictionary<string, string> initiallyLastActiveStates;
 
         public HierarchyBuilderTest()
         {
             this.superState = new StateDefinition<string, int>(SuperState);
             this.states = A.Fake<IImplicitAddIfNotAvailableStateDefinitionDictionary<string, int>>();
             A.CallTo(() => this.states[SuperState]).Returns(this.superState);
-            this.initiallyLastActiveStates = A.Fake<IDictionary<string, IStateDefinition<string, int>>>();
+            this.initiallyLastActiveStates = A.Fake<IDictionary<string, string>>();
 
             this.testee = new HierarchyBuilder<string, int>(SuperState, this.states, this.initiallyLastActiveStates);
         }
@@ -84,7 +84,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
 
             this.testee.WithInitialSubState(SubState);
 
-            A.CallTo(() => this.initiallyLastActiveStates.Add(SuperState, subState)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => this.initiallyLastActiveStates.Add(SuperState, subState.Id)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]

--- a/source/Appccelerate.StateMachine.Facts/Machine/StateActionTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/StateActionTest.cs
@@ -43,7 +43,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
             entered.Should().BeTrue("entry action was not executed.");
         }
@@ -66,7 +66,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
             entered1.Should().BeTrue("entry action was not executed.");
             entered2.Should().BeTrue("entry action was not executed.");
@@ -90,7 +90,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
             receivedValue.Should().Be(Parameter);
         }
@@ -112,7 +112,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, stateContainer, stateContainer, stateDefinitions);
 
@@ -138,7 +138,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, stateContainer, stateContainer, stateDefinitions);
 
@@ -165,7 +165,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, stateContainer, stateContainer, stateDefinitions);
 

--- a/source/Appccelerate.StateMachine.Facts/Machine/StateContainerTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/StateContainerTest.cs
@@ -67,7 +67,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
         public void ExtensionsWhenExtensionsAreClearedThenNoExtensionIsRegistered()
         {
             var executed = false;
-            var extension = A.Fake<IExtension<string, int>>();
+            var extension = A.Fake<IExtensionInternal<string, int>>();
 
             var testee = new StateContainer<string, int>();
 

--- a/source/Appccelerate.StateMachine.Facts/Machine/StateContainerTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/StateContainerTest.cs
@@ -20,6 +20,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
 {
     using FakeItEasy;
     using FluentAssertions;
+    using StateMachine.Infrastructure;
     using StateMachine.Machine;
     using Xunit;
 

--- a/source/Appccelerate.StateMachine.Facts/Machine/StateContainerTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/StateContainerTest.cs
@@ -21,7 +21,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
     using FakeItEasy;
     using FluentAssertions;
     using StateMachine.Machine;
-    using StateMachine.Machine.States;
     using Xunit;
 
     public class StateContainerTest
@@ -32,28 +31,36 @@ namespace Appccelerate.StateMachine.Facts.Machine
             const string Name = "container";
             var stateContainer = new StateContainer<string, int>(Name);
 
-            stateContainer.Name.Should().Be(Name);
+            stateContainer
+                .Name
+                .Should()
+                .Be(Name);
         }
 
         [Fact]
-        public void ReturnsNullAsLastActiveStateWhenStateWasNeverSet()
+        public void ReturnsNothingAsLastActiveStateWhenStateWasNeverSet()
         {
-            var stateContainer = new StateContainer<string, int>("container");
+            var stateContainer = new StateContainer<string, int>();
 
-            stateContainer.SetLastActiveStateFor("A", A.Fake<IStateDefinition<string, int>>());
+            stateContainer.SetLastActiveStateFor("A", "helloWorld");
 
-            stateContainer.GetLastActiveStateOrNullFor("B").Should().BeNull();
+            stateContainer
+                .GetLastActiveStateFor("B")
+                .Should()
+                .BeEquivalentTo(Optional<string>.Nothing());
         }
 
         [Fact]
-        public void ReturnsStateDefinitionXAsLastActiveStateWhenStateDefinitionXWasSetBefore()
+        public void ReturnsStateXAsLastActiveStateWhenXWasSetBefore()
         {
-            var stateContainer = new StateContainer<string, int>("container");
-            var lastActiveState = A.Fake<IStateDefinition<string, int>>();
+            var stateContainer = new StateContainer<string, int>();
 
-            stateContainer.SetLastActiveStateFor("A", lastActiveState);
+            stateContainer.SetLastActiveStateFor("A", "Z");
 
-            stateContainer.GetLastActiveStateOrNullFor("A").Should().Be(lastActiveState);
+            stateContainer
+                .GetLastActiveStateFor("A")
+                .Should()
+                .BeEquivalentTo(Optional<string>.Just("Z"));
         }
 
         [Fact]
@@ -70,7 +77,8 @@ namespace Appccelerate.StateMachine.Facts.Machine
             testee.ForEach(e => executed = true);
 
             executed
-                .Should().BeFalse();
+                .Should()
+                .BeFalse();
         }
     }
 }

--- a/source/Appccelerate.StateMachine.Facts/Machine/StateDefinitionsBuilder.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/StateDefinitionsBuilder.cs
@@ -21,7 +21,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
     using System;
     using System.Collections.Generic;
     using StateMachine.Machine;
-    using StateMachine.Machine.States;
     using StateMachine.Syntax;
 
     public class StateDefinitionsBuilder<TState, TEvent>
@@ -30,7 +29,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
     {
         private readonly StandardFactory<TState, TEvent> factory = new StandardFactory<TState, TEvent>();
         private readonly ImplicitAddIfNotAvailableStateDefinitionDictionary<TState, TEvent> stateDefinitionDictionary = new ImplicitAddIfNotAvailableStateDefinitionDictionary<TState, TEvent>();
-        private readonly Dictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates = new Dictionary<TState, IStateDefinition<TState, TEvent>>();
+        private readonly Dictionary<TState, TState> initiallyLastActiveStates = new Dictionary<TState, TState>();
 
         public IEntryActionSyntax<TState, TEvent> In(TState state)
         {

--- a/source/Appccelerate.StateMachine.Facts/Machine/StateMachineBuilder.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/StateMachineBuilder.cs
@@ -28,6 +28,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
         where TEvent : IComparable
     {
         private StateContainer<TState, TEvent> stateContainer;
+        private IStateDefinitionDictionary<TState, TEvent> stateDefinitions;
 
         public StateMachineBuilder()
         {
@@ -40,11 +41,17 @@ namespace Appccelerate.StateMachine.Facts.Machine
             return this;
         }
 
+        public StateMachineBuilder<TState, TEvent> WithStateDefinitions(IStateDefinitionDictionary<TState, TEvent> stateDefinitionsToUse)
+        {
+            this.stateDefinitions = stateDefinitionsToUse;
+            return this;
+        }
+
         public StateMachine<TState, TEvent> Build()
         {
             var factory = new StandardFactory<TState, TEvent>();
             var transitionLogic = new TransitionLogic<TState, TEvent>(this.stateContainer, this.stateContainer);
-            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, this.stateContainer, this.stateContainer);
+            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, this.stateContainer, this.stateContainer, this.stateDefinitions);
             transitionLogic.SetStateLogic(stateLogic);
 
             return new StateMachine<TState, TEvent>(factory, stateLogic);

--- a/source/Appccelerate.StateMachine.Facts/Machine/StateMachineBuilder.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/StateMachineBuilder.cs
@@ -43,8 +43,8 @@ namespace Appccelerate.StateMachine.Facts.Machine
         public StateMachine<TState, TEvent> Build()
         {
             var factory = new StandardFactory<TState, TEvent>();
-            var transitionLogic = new TransitionLogic<TState, TEvent>(this.stateContainer, this.stateContainer);
-            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, this.stateContainer, this.stateContainer);
+            var transitionLogic = new TransitionLogic<TState, TEvent>(this.stateContainer);
+            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, this.stateContainer);
             transitionLogic.SetStateLogic(stateLogic);
 
             return new StateMachine<TState, TEvent>(factory, stateLogic);

--- a/source/Appccelerate.StateMachine.Facts/Machine/StateMachineBuilder.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/StateMachineBuilder.cs
@@ -28,7 +28,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
         where TEvent : IComparable
     {
         private StateContainer<TState, TEvent> stateContainer;
-        private IStateDefinitionDictionary<TState, TEvent> stateDefinitions;
 
         public StateMachineBuilder()
         {
@@ -41,17 +40,11 @@ namespace Appccelerate.StateMachine.Facts.Machine
             return this;
         }
 
-        public StateMachineBuilder<TState, TEvent> WithStateDefinitions(IStateDefinitionDictionary<TState, TEvent> stateDefinitionsToUse)
-        {
-            this.stateDefinitions = stateDefinitionsToUse;
-            return this;
-        }
-
         public StateMachine<TState, TEvent> Build()
         {
             var factory = new StandardFactory<TState, TEvent>();
             var transitionLogic = new TransitionLogic<TState, TEvent>(this.stateContainer, this.stateContainer);
-            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, this.stateContainer, this.stateContainer, this.stateDefinitions);
+            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, this.stateContainer, this.stateContainer);
             transitionLogic.SetStateLogic(stateLogic);
 
             return new StateMachine<TState, TEvent>(factory, stateLogic);

--- a/source/Appccelerate.StateMachine.Facts/Machine/StateMachineTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/StateMachineTest.cs
@@ -173,7 +173,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
-                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.A);
@@ -197,7 +196,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
-                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.D1B);
@@ -223,7 +221,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
-                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             stateContainer.SetLastActiveStateFor(States.D, States.D1);
@@ -254,7 +251,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
-                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.E);
@@ -284,7 +280,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
-                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.B1);
@@ -314,7 +309,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
-                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.B2);
@@ -347,7 +341,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
-                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.D1B);
@@ -380,7 +373,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
-                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.A);
@@ -410,7 +402,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
-                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.B2);
@@ -436,7 +427,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
-                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.C1B);
@@ -468,7 +458,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
-                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.D1B);
@@ -499,7 +488,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
-                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.C1B);
@@ -529,7 +517,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
-                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.A);
@@ -549,7 +536,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
-                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.E);
@@ -573,7 +559,6 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
-                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.C1A);

--- a/source/Appccelerate.StateMachine.Facts/Machine/StateMachineTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/StateMachineTest.cs
@@ -23,7 +23,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
     using System.Linq;
     using System.Text;
     using FluentAssertions;
-    using Infrastructure;
+    using StateMachine.Infrastructure;
     using StateMachine.Machine;
     using Xunit;
 
@@ -173,6 +173,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
+                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.A);
@@ -196,6 +197,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
+                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.D1B);
@@ -221,10 +223,11 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
+                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
-            stateContainer.SetLastActiveStateFor(States.D, this.stateDefinitions[States.D1]);
-            stateContainer.SetLastActiveStateFor(States.D1, this.stateDefinitions[States.D1A]);
+            stateContainer.SetLastActiveStateFor(States.D, States.D1);
+            stateContainer.SetLastActiveStateFor(States.D1, States.D1A);
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.D);
 
@@ -251,6 +254,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
+                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.E);
@@ -280,6 +284,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
+                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.B1);
@@ -309,6 +314,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
+                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.B2);
@@ -341,6 +347,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
+                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.D1B);
@@ -373,6 +380,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
+                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.A);
@@ -402,6 +410,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
+                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.B2);
@@ -427,6 +436,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
+                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.C1B);
@@ -458,6 +468,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
+                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.D1B);
@@ -488,6 +499,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
+                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.C1B);
@@ -517,6 +529,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
+                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.A);
@@ -536,6 +549,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
+                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.E);
@@ -559,6 +573,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             var stateContainer = new StateContainer<States, Events>();
             var testee = new StateMachineBuilder<States, Events>()
                 .WithStateContainer(stateContainer)
+                .WithStateDefinitions(this.stateDefinitions)
                 .Build();
 
             testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.C1A);

--- a/source/Appccelerate.StateMachine.Facts/Machine/StateMachineTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/StateMachineTest.cs
@@ -175,7 +175,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, this.stateDefinitions, States.A);
 
             stateContainer
                 .CurrentStateId
@@ -198,7 +198,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.D1B);
+            testee.EnterInitialState(stateContainer, this.stateDefinitions, States.D1B);
 
             stateContainer
                 .CurrentStateId
@@ -226,7 +226,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
             stateContainer.SetLastActiveStateFor(States.D, States.D1);
             stateContainer.SetLastActiveStateFor(States.D1, States.D1A);
 
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.D);
+            testee.EnterInitialState(stateContainer, this.stateDefinitions, States.D);
 
             stateContainer
                 .CurrentStateId
@@ -253,7 +253,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.E);
+            testee.EnterInitialState(stateContainer, this.stateDefinitions, States.E);
 
             this.ClearRecords();
 
@@ -282,7 +282,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.B1);
+            testee.EnterInitialState(stateContainer, this.stateDefinitions, States.B1);
 
             this.ClearRecords();
 
@@ -311,7 +311,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.B2);
+            testee.EnterInitialState(stateContainer, this.stateDefinitions, States.B2);
 
             this.ClearRecords();
 
@@ -343,7 +343,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.D1B);
+            testee.EnterInitialState(stateContainer, this.stateDefinitions, States.D1B);
 
             this.ClearRecords();
 
@@ -375,7 +375,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, this.stateDefinitions, States.A);
 
             this.ClearRecords();
 
@@ -404,7 +404,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.B2);
+            testee.EnterInitialState(stateContainer, this.stateDefinitions, States.B2);
             testee.Fire(Events.A, stateContainer, stateContainer, this.stateDefinitions);
 
             this.ClearRecords();
@@ -429,7 +429,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.C1B);
+            testee.EnterInitialState(stateContainer, this.stateDefinitions, States.C1B);
             testee.Fire(Events.A, stateContainer, stateContainer, this.stateDefinitions);
 
             this.ClearRecords();
@@ -460,7 +460,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.D1B);
+            testee.EnterInitialState(stateContainer, this.stateDefinitions, States.D1B);
             testee.Fire(Events.A, stateContainer, stateContainer, this.stateDefinitions);
 
             this.ClearRecords();
@@ -490,7 +490,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.C1B);
+            testee.EnterInitialState(stateContainer, this.stateDefinitions, States.C1B);
 
             this.ClearRecords();
 
@@ -519,7 +519,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, this.stateDefinitions, States.A);
             this.ClearRecords();
 
             testee.Fire(Events.A, stateContainer, stateContainer, this.stateDefinitions);
@@ -538,7 +538,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.E);
+            testee.EnterInitialState(stateContainer, this.stateDefinitions, States.E);
             this.ClearRecords();
 
             testee.Fire(Events.E, stateContainer, stateContainer, this.stateDefinitions);
@@ -561,7 +561,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, this.stateDefinitions, States.C1A);
+            testee.EnterInitialState(stateContainer, this.stateDefinitions, States.C1A);
             this.ClearRecords();
 
             testee.Fire(Events.C1B, stateContainer, stateContainer, this.stateDefinitions);

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/ExceptionThrowingActionTransitionTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/ExceptionThrowingActionTransitionTest.cs
@@ -46,14 +46,14 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void CallsExtensionToHandleException()
         {
-            var extension = A.Fake<IExtension<States, Events>>();
+            var extension = A.Fake<IExtensionInternal<States, Events>>();
 
             this.ExtensionHost.Extension = extension;
 
             this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
-            A.CallTo(() => extension.HandlingTransitionException(this.StateMachineInformation, this.TransitionDefinition, this.TransitionContext, ref this.exception)).MustHaveHappened();
-            A.CallTo(() => extension.HandledTransitionException(this.StateMachineInformation, this.TransitionDefinition, this.TransitionContext, this.exception)).MustHaveHappened();
+            A.CallTo(() => extension.HandlingTransitionException(this.TransitionDefinition, this.TransitionContext, ref this.exception)).MustHaveHappened();
+            A.CallTo(() => extension.HandledTransitionException(this.TransitionDefinition, this.TransitionContext, this.exception)).MustHaveHappened();
         }
 
         [Fact]

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/ExceptionThrowingActionTransitionTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/ExceptionThrowingActionTransitionTest.cs
@@ -50,7 +50,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
 
             this.ExtensionHost.Extension = extension;
 
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => extension.HandlingTransitionException(this.StateMachineInformation, this.TransitionDefinition, this.TransitionContext, ref this.exception)).MustHaveHappened();
             A.CallTo(() => extension.HandledTransitionException(this.StateMachineInformation, this.TransitionDefinition, this.TransitionContext, this.exception)).MustHaveHappened();
@@ -59,7 +59,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void ReturnsFiredTransitionResult()
         {
-            var result = this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            var result = this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             result.Fired.Should().BeTrue();
         }
@@ -67,7 +67,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void NotifiesExceptionOnTransitionContext()
         {
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.TransitionContext.OnExceptionThrown(this.exception)).MustHaveHappened();
         }

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/ExceptionThrowingGuardTransitionTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/ExceptionThrowingGuardTransitionTest.cs
@@ -50,7 +50,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
 
             this.ExtensionHost.Extension = extension;
 
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => extension.HandlingGuardException(this.StateMachineInformation, this.TransitionDefinition, this.TransitionContext, ref this.exception)).MustHaveHappened();
             A.CallTo(() => extension.HandledGuardException(this.StateMachineInformation, this.TransitionDefinition, this.TransitionContext, this.exception)).MustHaveHappened();
@@ -59,7 +59,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void ReturnsNotFiredTransitionResult()
         {
-            var result = this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            var result = this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             result.Fired.Should().BeFalse();
         }
@@ -67,7 +67,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void NotifiesExceptionOnTransitionContext()
         {
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.TransitionContext.OnExceptionThrown(this.exception)).MustHaveHappened();
         }

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/ExceptionThrowingGuardTransitionTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/ExceptionThrowingGuardTransitionTest.cs
@@ -46,14 +46,14 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void CallsExtensionToHandleException()
         {
-            var extension = A.Fake<IExtension<States, Events>>();
+            var extension = A.Fake<IExtensionInternal<States, Events>>();
 
             this.ExtensionHost.Extension = extension;
 
             this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
-            A.CallTo(() => extension.HandlingGuardException(this.StateMachineInformation, this.TransitionDefinition, this.TransitionContext, ref this.exception)).MustHaveHappened();
-            A.CallTo(() => extension.HandledGuardException(this.StateMachineInformation, this.TransitionDefinition, this.TransitionContext, this.exception)).MustHaveHappened();
+            A.CallTo(() => extension.HandlingGuardException(this.TransitionDefinition, this.TransitionContext, ref this.exception)).MustHaveHappened();
+            A.CallTo(() => extension.HandledGuardException(this.TransitionDefinition, this.TransitionContext, this.exception)).MustHaveHappened();
         }
 
         [Fact]

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/GuardsTransitionTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/GuardsTransitionTest.cs
@@ -42,7 +42,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
             var guard = Builder<States, Events>.CreateGuardHolder().ReturningTrue().Build();
             this.TransitionDefinition.Guard = guard;
 
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.Target, this.TransitionContext)).MustHaveHappenedOnceExactly();
         }
@@ -53,7 +53,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
             var guard = Builder<States, Events>.CreateGuardHolder().ReturningFalse().Build();
             this.TransitionDefinition.Guard = guard;
 
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.Target, this.TransitionContext)).MustNotHaveHappened();
         }
@@ -64,7 +64,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
             var guard = Builder<States, Events>.CreateGuardHolder().ReturningFalse().Build();
             this.TransitionDefinition.Guard = guard;
 
-            var result = this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            var result = this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             result.Should().BeNotFiredTransitionResult<States>();
         }
@@ -78,7 +78,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
             var guard = Builder<States, Events>.CreateGuardHolder().ReturningFalse().Build();
             this.TransitionDefinition.Guard = guard;
 
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => extension.SkippedTransition(
                 this.StateMachineInformation,

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/GuardsTransitionTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/GuardsTransitionTest.cs
@@ -72,7 +72,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void NotifiesExtensions_WhenGuardIsNotMet()
         {
-            var extension = A.Fake<IExtension<States, Events>>();
+            var extension = A.Fake<IExtensionInternal<States, Events>>();
             this.ExtensionHost.Extension = extension;
 
             var guard = Builder<States, Events>.CreateGuardHolder().ReturningFalse().Build();
@@ -81,7 +81,6 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
             this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => extension.SkippedTransition(
-                this.StateMachineInformation,
                 A<ITransitionDefinition<States, Events>>.That.Matches(t => t.Source == this.Source && t.Target == this.Target),
                 this.TransitionContext)).MustHaveHappened();
         }

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/HierarchicalTransitionTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/HierarchicalTransitionTest.cs
@@ -45,7 +45,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void ExitsStatesUpToBelowCommonSuperState()
         {
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Exit(this.Source, this.TransitionContext, this.LastActiveStateModifier)).MustHaveHappened()
                 .Then(A.CallTo(() => this.StateLogic.Exit(this.superStateOfSource, this.TransitionContext, this.LastActiveStateModifier)).MustHaveHappened());
@@ -54,7 +54,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void EntersStatesBelowCommonSuperStateToTarget()
         {
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.superStateOfTarget, this.TransitionContext)).MustHaveHappened()
                 .Then(A.CallTo(() => this.StateLogic.Entry(this.Target, this.TransitionContext)).MustHaveHappened());
@@ -63,7 +63,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void DoesNotExitCommonSuperState()
         {
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Exit(this.root, this.TransitionContext, this.LastActiveStateModifier)).MustNotHaveHappened();
         }
@@ -71,7 +71,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void DoesNotEnterCommonSuperState()
         {
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.root, this.TransitionContext)).MustNotHaveHappened();
         }

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/InternalTransitionTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/InternalTransitionTest.cs
@@ -36,7 +36,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void DoesNotExitState()
         {
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Exit(this.Source, this.TransitionContext, this.LastActiveStateModifier)).MustNotHaveHappened();
         }
@@ -44,7 +44,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void DoesNotEnterState()
         {
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.Source, this.TransitionContext)).MustNotHaveHappened();
         }

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/SelfTransitionTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/SelfTransitionTest.cs
@@ -36,7 +36,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void ExitsState()
         {
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Exit(this.Source, this.TransitionContext, this.LastActiveStateModifier)).MustHaveHappened();
         }
@@ -44,7 +44,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void EntersState()
         {
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.Target, this.TransitionContext)).MustHaveHappened();
         }

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/SourceIsDescendantOfTargetTransitionTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/SourceIsDescendantOfTargetTransitionTest.cs
@@ -40,7 +40,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void ExitsOfAllStatesFromSourceUpToTarget()
         {
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Exit(this.Source, this.TransitionContext, this.LastActiveStateModifier)).MustHaveHappened()
                 .Then(A.CallTo(() => this.StateLogic.Exit(this.intermediate, this.TransitionContext, this.LastActiveStateModifier)).MustHaveHappened())
@@ -50,7 +50,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void EntersTargetState()
         {
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.Target, this.TransitionContext)).MustHaveHappened();
         }

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/SourceIsParentOfTargetTransitionTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/SourceIsParentOfTargetTransitionTest.cs
@@ -40,7 +40,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void EntersAllStatesBelowSourceDownToTarget()
         {
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.intermediate, this.TransitionContext)).MustHaveHappened()
                 .Then(A.CallTo(() => this.StateLogic.Entry(this.Target, this.TransitionContext)).MustHaveHappened());

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/SuccessfulTransitionWithExecutedActionsTestBase.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/SuccessfulTransitionWithExecutedActionsTestBase.cs
@@ -58,22 +58,20 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
             this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             extension.Items.Should().Contain(new FakeExtension.Item(
-                this.StateMachineInformation,
                 this.Source,
                 this.Target,
                 this.TransitionContext));
         }
 
-        public class FakeExtension : ExtensionBase<States, Events>
+        public class FakeExtension : InternalExtensionBase<States, Events>
         {
             private readonly List<Item> items = new List<Item>();
 
             public override void ExecutedTransition(
-                IStateMachineInformation<States, Events> stateMachine,
                 ITransitionDefinition<States, Events> transition,
                 ITransitionContext<States, Events> transitionContext)
             {
-                this.items.Add(new Item(stateMachine, transition.Source, transition.Target, transitionContext));
+                this.items.Add(new Item(transition.Source, transition.Target, transitionContext));
             }
 
             public IReadOnlyCollection<Item> Items => this.items;
@@ -83,7 +81,6 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
                 private bool Equals(Item other)
                 {
                     return
-                        Equals(this.StateMachine, other.StateMachine) &&
                         Equals(this.Source, other.Source) &&
                         (Equals(this.Target, other.Target) || (this.Target == null && other.Target == other.Source)) && // in case of an internal-transition, this.Target (from TransitionContext) is null (wherease it would be == this.Source in case of an self-transition) therefor we check the we did not switch state in this case
                         Equals(this.TransitionContext, other.TransitionContext);
@@ -113,8 +110,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
                 {
                     unchecked
                     {
-                        var hashCode = this.StateMachine != null ? this.StateMachine.GetHashCode() : 0;
-                        hashCode = (hashCode * 397) ^ (this.Source != null ? this.Source.GetHashCode() : 0);
+                        var hashCode = this.Source != null ? this.Source.GetHashCode() : 0;
                         hashCode = (hashCode * 397) ^ (this.Target != null ? this.Target.GetHashCode() : 0);
                         hashCode = (hashCode * 397) ^ (this.TransitionContext != null ? this.TransitionContext.GetHashCode() : 0);
                         return hashCode;
@@ -122,18 +118,14 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
                 }
 
                 public Item(
-                    IStateMachineInformation<States, Events> stateMachine,
                     IStateDefinition<States, Events> source,
                     IStateDefinition<States, Events> target,
                     ITransitionContext<States, Events> transitionContext)
                 {
-                    this.StateMachine = stateMachine;
                     this.Source = source;
                     this.Target = target;
                     this.TransitionContext = transitionContext;
                 }
-
-                public IStateMachineInformation<States, Events> StateMachine { get; }
 
                 public IStateDefinition<States, Events> Source { get; }
 

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/SuccessfulTransitionWithExecutedActionsTestBase.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/SuccessfulTransitionWithExecutedActionsTestBase.cs
@@ -32,7 +32,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void ReturnsSuccessfulTransitionResult()
         {
-            var result = this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            var result = this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             result.Should().BeSuccessfulTransitionResultWithNewState(this.Target);
         }
@@ -44,7 +44,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
 
             this.TransitionDefinition.ActionsModifiable.Add(new ArgumentLessActionHolder(() => executed = true));
 
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             executed.Should().BeTrue("actions should be executed");
         }
@@ -55,7 +55,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
             var extension = new FakeExtension();
             this.ExtensionHost.Extension = extension;
 
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             extension.Items.Should().Contain(new FakeExtension.Item(
                 this.StateMachineInformation,

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/TransitionDefinedInSuperStateTransitionTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/TransitionDefinedInSuperStateTransitionTest.cs
@@ -42,7 +42,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void ExitsAllStatesFromCurrentUpToSource()
         {
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Exit(this.current, this.TransitionContext, this.LastActiveStateModifier)).MustHaveHappened()
                 .Then(A.CallTo(() => this.StateLogic.Exit(this.intermediate, this.TransitionContext, this.LastActiveStateModifier)).MustHaveHappened())

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/TransitionTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/TransitionTest.cs
@@ -36,7 +36,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void EntersDestinationState()
         {
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Entry(this.Target, this.TransitionContext)).MustHaveHappenedOnceExactly();
         }
@@ -44,7 +44,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void ExitsSourceState()
         {
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.StateLogic.Exit(this.Source, this.TransitionContext, this.LastActiveStateModifier)).MustHaveHappenedOnceExactly();
         }
@@ -52,7 +52,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         [Fact]
         public void NotifiesTransitionBeginOnTransitionContext()
         {
-            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier);
+            this.Testee.Fire(this.TransitionDefinition, this.TransitionContext, this.LastActiveStateModifier, this.StateDefinitions);
 
             A.CallTo(() => this.TransitionContext.OnTransitionBegin()).MustHaveHappened();
         }

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/TransitionTestBase.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/TransitionTestBase.cs
@@ -40,7 +40,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
 
         protected IStateLogic<States, Events> StateLogic { get; }
 
-        protected ILastActiveStateModifier<States, Events> LastActiveStateModifier { get; }
+        protected ILastActiveStateModifier<States> LastActiveStateModifier { get; }
 
         protected TestableExtensionHost ExtensionHost { get; }
 
@@ -55,7 +55,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         public TransitionTestBase()
         {
             this.StateLogic = A.Fake<IStateLogic<States, Events>>();
-            this.LastActiveStateModifier = A.Fake<ILastActiveStateModifier<States, Events>>();
+            this.LastActiveStateModifier = A.Fake<ILastActiveStateModifier<States>>();
             this.StateMachineInformation = A.Fake<IStateMachineInformation<States, Events>>();
             this.ExtensionHost = new TestableExtensionHost();
             this.TransitionDefinition = new TransitionDefinition<States, Events>();

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/TransitionTestBase.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/TransitionTestBase.cs
@@ -44,8 +44,6 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
 
         protected TestableExtensionHost ExtensionHost { get; }
 
-        protected IStateMachineInformation<States, Events> StateMachineInformation { get; }
-
         protected IStateDefinitionDictionary<States, Events> StateDefinitions { get; }
 
         protected IStateDefinition<States, Events> Source { get; set; }
@@ -59,7 +57,6 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
             this.StateLogic = A.Fake<IStateLogic<States, Events>>();
             this.LastActiveStateModifier = A.Fake<ILastActiveStateModifier<States>>();
             this.StateDefinitions = A.Fake<IStateDefinitionDictionary<States, Events>>();
-            this.StateMachineInformation = A.Fake<IStateMachineInformation<States, Events>>();
             this.ExtensionHost = new TestableExtensionHost();
             this.TransitionDefinition = new TransitionDefinition<States, Events>();
 

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/TransitionTestBase.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/TransitionTestBase.cs
@@ -63,15 +63,15 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
             this.ExtensionHost = new TestableExtensionHost();
             this.TransitionDefinition = new TransitionDefinition<States, Events>();
 
-            this.Testee = new TransitionLogic<States, Events>(this.ExtensionHost, this.StateMachineInformation);
+            this.Testee = new TransitionLogic<States, Events>(this.ExtensionHost);
             this.Testee.SetStateLogic(this.StateLogic);
         }
 
         public class TestableExtensionHost : IExtensionHost<States, Events>
         {
-            public IExtension<States, Events> Extension { private get; set; }
+            public IExtensionInternal<States, Events> Extension { private get; set; }
 
-            public void ForEach(Action<IExtension<States, Events>> action)
+            public void ForEach(Action<IExtensionInternal<States, Events>> action)
             {
                 if (this.Extension != null)
                 {

--- a/source/Appccelerate.StateMachine.Facts/Machine/Transitions/TransitionTestBase.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/Transitions/TransitionTestBase.cs
@@ -46,6 +46,8 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
 
         protected IStateMachineInformation<States, Events> StateMachineInformation { get; }
 
+        protected IStateDefinitionDictionary<States, Events> StateDefinitions { get; }
+
         protected IStateDefinition<States, Events> Source { get; set; }
 
         protected IStateDefinition<States, Events> Target { get; set; }
@@ -56,6 +58,7 @@ namespace Appccelerate.StateMachine.Facts.Machine.Transitions
         {
             this.StateLogic = A.Fake<IStateLogic<States, Events>>();
             this.LastActiveStateModifier = A.Fake<ILastActiveStateModifier<States>>();
+            this.StateDefinitions = A.Fake<IStateDefinitionDictionary<States, Events>>();
             this.StateMachineInformation = A.Fake<IStateMachineInformation<States, Events>>();
             this.ExtensionHost = new TestableExtensionHost();
             this.TransitionDefinition = new TransitionDefinition<States, Events>();

--- a/source/Appccelerate.StateMachine.Facts/Machine/TransitionsTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/TransitionsTest.cs
@@ -52,7 +52,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
 
             testee.TransitionDeclined += (sender, e) => { declined = true; };
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.C, stateContainer, stateContainer, stateDefinitions);
 
@@ -88,9 +88,9 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
-            testee.Fire(Events.B, EventArgument, stateContainer, stateContainer, stateDefinitions);
+            testee.Fire(Events.B, EventArgument, stateContainer, stateDefinitions);
 
             action1Argument.Should().Be(EventArgument);
             action2Argument.Should().Be(EventArgument);
@@ -118,9 +118,9 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
-            testee.Fire(Events.B, EventArgument, stateContainer, stateContainer, stateDefinitions);
+            testee.Fire(Events.B, EventArgument, stateContainer, stateDefinitions);
 
             action1Executed.Should().BeTrue("action with argument should be executed");
             action2Executed.Should().BeTrue("action without argument should be executed");
@@ -148,7 +148,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.A, stateContainer, stateContainer, stateDefinitions);
 
@@ -176,7 +176,7 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
             testee.Fire(Events.B, stateContainer, stateContainer, stateDefinitions);
 
@@ -201,9 +201,9 @@ namespace Appccelerate.StateMachine.Facts.Machine
                 .WithStateContainer(stateContainer)
                 .Build();
 
-            testee.EnterInitialState(stateContainer, stateContainer, stateDefinitions, States.A);
+            testee.EnterInitialState(stateContainer, stateDefinitions, States.A);
 
-            testee.Fire(Events.B, ExpectedValue, stateContainer, stateContainer, stateDefinitions);
+            testee.Fire(Events.B, ExpectedValue, stateContainer, stateDefinitions);
 
             value.Should().Be(ExpectedValue);
         }

--- a/source/Appccelerate.StateMachine.Facts/Machine/TransitionsTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/Machine/TransitionsTest.cs
@@ -19,7 +19,7 @@
 namespace Appccelerate.StateMachine.Facts.Machine
 {
     using FluentAssertions;
-    using Infrastructure;
+    using StateMachine.Infrastructure;
     using StateMachine.Machine;
     using Xunit;
 

--- a/source/Appccelerate.StateMachine.Facts/OptionalTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/OptionalTest.cs
@@ -1,5 +1,5 @@
 ﻿//-------------------------------------------------------------------------------
-// <copyright file="ILastActiveStateModifier.cs" company="Appccelerate">
+// <copyright file="OptionalTest.cs" company="Appccelerate">
 //   Copyright (c) 2008-2019 Appccelerate
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,15 +16,28 @@
 // </copyright>
 //-------------------------------------------------------------------------------
 
-namespace Appccelerate.StateMachine.Machine
+namespace Appccelerate.StateMachine.Facts
 {
-    using System;
+    using FluentAssertions;
+    using StateMachine.Machine;
+    using Xunit;
 
-    public interface ILastActiveStateModifier<TState>
-        where TState : IComparable
+    public class OptionalTest
     {
-        Optional<TState> GetLastActiveStateFor(TState state);
+        [Fact]
+        public void IsInitialized()
+        {
+            Optional<string>
+                .Just("hello world")
+                .HasValue
+                .Should()
+                .BeTrue();
 
-        void SetLastActiveStateFor(TState state, TState newLastActiveState);
+            Optional<string>
+                .Nothing()
+                .HasValue
+                .Should()
+                .BeFalse();
+        }
     }
 }

--- a/source/Appccelerate.StateMachine.Facts/OptionalTest.cs
+++ b/source/Appccelerate.StateMachine.Facts/OptionalTest.cs
@@ -19,7 +19,7 @@
 namespace Appccelerate.StateMachine.Facts
 {
     using FluentAssertions;
-    using StateMachine.Machine;
+    using StateMachine.Infrastructure;
     using Xunit;
 
     public class OptionalTest

--- a/source/Appccelerate.StateMachine.Specs/Async/Persisting.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/Persisting.cs
@@ -196,12 +196,13 @@ namespace Appccelerate.StateMachine.Specs.Async
         {
             public List<IInitializable<State>> LoadedCurrentState { get; } = new List<IInitializable<State>>();
 
-            public override void Loaded(
+            public override Task Loaded(
                 IStateMachineInformation<State, Event> stateMachineInformation,
                 IInitializable<State> loadedCurrentState,
                 IReadOnlyDictionary<State, State> loadedHistoryStates)
             {
                 this.LoadedCurrentState.Add(loadedCurrentState);
+                return Task.CompletedTask;
             }
         }
 

--- a/source/Appccelerate.StateMachine.Specs/Async/Persisting.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/Persisting.cs
@@ -257,17 +257,41 @@ namespace Appccelerate.StateMachine.Specs.Async
 
             "when it is loaded with Events".x(async () =>
             {
+                var firstEvent = new EventInformation<int>(2, null);
+                var secondEvent = new EventInformation<int>(3, null);
+                var priorityEvent = new EventInformation<int>(1, null);
                 var loader = new StateMachineLoader<string, int>();
                 loader.SetEvents(new List<EventInformation<int>>
                 {
-                    new EventInformation<int>(2, null),
-                    new EventInformation<int>(3, null),
+                    firstEvent,
+                    secondEvent,
                 });
                 loader.SetPriorityEvents(new List<EventInformation<int>>
                 {
-                    new EventInformation<int>(1, null)
+                    priorityEvent
                 });
+
+                var extension = A.Fake<IExtension<string, int>>();
+                machine.AddExtension(extension);
+
                 await machine.Load(loader);
+
+                A.CallTo(() => extension.Loaded(
+                        A<IStateMachineInformation<string, int>>.Ignored,
+                        A<Initializable<string>>.Ignored,
+                        A<IReadOnlyDictionary<string, string>>.Ignored,
+                        A<IReadOnlyCollection<EventInformation<int>>>
+                            .That
+                            .Matches(c =>
+                                c.Count == 2
+                                && c.Contains(firstEvent)
+                                && c.Contains(secondEvent)),
+                        A<IReadOnlyCollection<EventInformation<int>>>
+                            .That
+                            .Matches(c =>
+                                c.Count == 1
+                                && c.Contains(priorityEvent))))
+                    .MustHaveHappenedOnceExactly();
             });
 
             "it should process those events".x(async () =>
@@ -377,17 +401,41 @@ namespace Appccelerate.StateMachine.Specs.Async
 
             "when it is loaded with Events".x(async () =>
             {
+                var firstEvent = new EventInformation<int>(2, null);
+                var secondEvent = new EventInformation<int>(3, null);
+                var priorityEvent = new EventInformation<int>(1, null);
                 var loader = new StateMachineLoader<string, int>();
                 loader.SetEvents(new List<EventInformation<int>>
                 {
-                    new EventInformation<int>(2, null),
-                    new EventInformation<int>(3, null),
+                    firstEvent,
+                    secondEvent,
                 });
                 loader.SetPriorityEvents(new List<EventInformation<int>>
                 {
-                    new EventInformation<int>(1, null)
+                    priorityEvent
                 });
+
+                var extension = A.Fake<IExtension<string, int>>();
+                machine.AddExtension(extension);
+
                 await machine.Load(loader);
+
+                A.CallTo(() => extension.Loaded(
+                        A<IStateMachineInformation<string, int>>.Ignored,
+                        A<Initializable<string>>.Ignored,
+                        A<IReadOnlyDictionary<string, string>>.Ignored,
+                        A<IReadOnlyCollection<EventInformation<int>>>
+                            .That
+                            .Matches(c =>
+                                c.Count == 2
+                                && c.Contains(firstEvent)
+                                && c.Contains(secondEvent)),
+                        A<IReadOnlyCollection<EventInformation<int>>>
+                            .That
+                            .Matches(c =>
+                                c.Count == 1
+                                && c.Contains(priorityEvent))))
+                    .MustHaveHappenedOnceExactly();
             });
 
             "it should process those events".x(async () =>
@@ -484,7 +532,9 @@ namespace Appccelerate.StateMachine.Specs.Async
             public override Task Loaded(
                 IStateMachineInformation<State, Event> stateMachineInformation,
                 IInitializable<State> loadedCurrentState,
-                IReadOnlyDictionary<State, State> loadedHistoryStates)
+                IReadOnlyDictionary<State, State> loadedHistoryStates,
+                IReadOnlyCollection<EventInformation<Event>> events,
+                IReadOnlyCollection<EventInformation<Event>> priorityEvents)
             {
                 this.LoadedCurrentState.Add(loadedCurrentState);
                 return Task.CompletedTask;

--- a/source/Appccelerate.StateMachine.Specs/Async/Persisting.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/Persisting.cs
@@ -20,6 +20,8 @@ namespace Appccelerate.StateMachine.Specs.Async
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AsyncMachine;
     using FakeItEasy;
@@ -46,8 +48,8 @@ namespace Appccelerate.StateMachine.Specs.Async
 
         [Scenario]
         public void Loading(
-            StateMachineSaver<State> saver,
-            StateMachineLoader<State> loader,
+            StateMachineSaver<State, Event> saver,
+            StateMachineLoader<State, Event> loader,
             FakeExtension extension,
             State sourceState,
             State targetState)
@@ -65,8 +67,8 @@ namespace Appccelerate.StateMachine.Specs.Async
                 await machine.Fire(Event.S2); // set history of super state S
                 await machine.Fire(Event.B);  // set current state to B
 
-                saver = new StateMachineSaver<State>();
-                loader = new StateMachineLoader<State>();
+                saver = new StateMachineSaver<State, Event>();
+                loader = new StateMachineLoader<State, Event>();
 
                 await machine.Save(saver);
             });
@@ -117,7 +119,7 @@ namespace Appccelerate.StateMachine.Specs.Async
         {
             "when a non-initialized state machine is loaded".x(async () =>
             {
-                var loader = new StateMachineLoader<State>();
+                var loader = new StateMachineLoader<State, Event>();
                 loader.SetCurrentState(Initializable<State>.UnInitialized());
                 loader.SetHistoryStates(new Dictionary<State, State>());
 
@@ -132,7 +134,7 @@ namespace Appccelerate.StateMachine.Specs.Async
 
             "it should not be initialized already".x(async () =>
             {
-                var stateMachineSaver = new StateMachineSaver<State>();
+                var stateMachineSaver = new StateMachineSaver<State, Event>();
                 await loadedMachine.Save(stateMachineSaver);
                 stateMachineSaver
                     .CurrentStateId
@@ -160,12 +162,255 @@ namespace Appccelerate.StateMachine.Specs.Async
 
             "when state machine is loaded".x(async () =>
                 receivedException = await Catch.Exception(async () =>
-                    await machine.Load(A.Fake<IAsyncStateMachineLoader<string>>())));
+                    await machine.Load(A.Fake<IAsyncStateMachineLoader<string, int>>())));
 
             "it should throw invalid operation exception".x(() =>
             {
                 receivedException.Should().BeOfType<InvalidOperationException>();
                 receivedException.Message.Should().Be(ExceptionMessages.StateMachineIsAlreadyInitialized);
+            });
+        }
+
+        [Scenario]
+        public void SavingEventsForPassiveStateMachine(
+            AsyncPassiveStateMachine<string, int> machine,
+            StateMachineSaver<string, int> saver)
+        {
+            "establish a state machine".x(() =>
+            {
+                var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<string, int>();
+                stateMachineDefinitionBuilder
+                    .In("A")
+                    .On(1)
+                    .Goto("B");
+                stateMachineDefinitionBuilder
+                    .In("B")
+                    .On(2)
+                    .Goto("C");
+                stateMachineDefinitionBuilder
+                    .In("C")
+                    .On(3)
+                    .Goto("A");
+                machine = stateMachineDefinitionBuilder
+                    .WithInitialState("A")
+                    .Build()
+                    .CreatePassiveStateMachine();
+            });
+
+            "when events are fired".x(async () =>
+            {
+                await machine.Fire(1);
+                await machine.Fire(2);
+                await machine.FirePriority(3);
+                await machine.FirePriority(4);
+            });
+
+            "and it is saved".x(async () =>
+            {
+                saver = new StateMachineSaver<string, int>();
+                await machine.Save(saver);
+            });
+
+            "it should save those events".x(() =>
+            {
+                saver
+                    .Events
+                    .Select(x => x.EventId)
+                    .Should()
+                    .HaveCount(2)
+                    .And
+                    .ContainInOrder(1, 2);
+                saver
+                    .PriorityEvents
+                    .Select(x => x.EventId)
+                    .Should()
+                    .HaveCount(2)
+                    .And
+                    .ContainInOrder(4, 3);
+            });
+        }
+
+        [Scenario]
+        public void LoadingEventsForPassiveStateMachine(
+            AsyncPassiveStateMachine<string, int> machine)
+        {
+            "establish a passive state machine".x(() =>
+            {
+                var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<string, int>();
+                stateMachineDefinitionBuilder
+                    .In("A")
+                    .On(1)
+                    .Goto("B");
+                stateMachineDefinitionBuilder
+                    .In("B")
+                    .On(2)
+                    .Goto("C");
+                stateMachineDefinitionBuilder
+                    .In("C")
+                    .On(3)
+                    .Goto("A");
+                machine = stateMachineDefinitionBuilder
+                    .WithInitialState("A")
+                    .Build()
+                    .CreatePassiveStateMachine();
+            });
+
+            "when it is loaded with Events".x(async () =>
+            {
+                var loader = new StateMachineLoader<string, int>();
+                loader.SetEvents(new List<EventInformation<int>>
+                {
+                    new EventInformation<int>(2, null),
+                    new EventInformation<int>(3, null),
+                });
+                loader.SetPriorityEvents(new List<EventInformation<int>>
+                {
+                    new EventInformation<int>(1, null)
+                });
+                await machine.Load(loader);
+            });
+
+            "it should process those events".x(async () =>
+            {
+                var transitionRecords = new List<TransitionRecord>();
+                machine.TransitionCompleted += (sender, args) =>
+                    transitionRecords.Add(
+                        new TransitionRecord(args.EventId, args.StateId, args.NewStateId));
+
+                await machine.Start();
+                transitionRecords
+                    .Should()
+                    .HaveCount(3)
+                    .And
+                    .IsEquivalentInOrder(new List<TransitionRecord>
+                    {
+                        new TransitionRecord(1, "A", "B"),
+                        new TransitionRecord(2, "B", "C"),
+                        new TransitionRecord(3, "C", "A")
+                    });
+            });
+        }
+
+        [Scenario]
+        public void SavingEventsForActiveStateMachine(
+            AsyncActiveStateMachine<string, int> machine,
+            StateMachineSaver<string, int> saver)
+        {
+            "establish a state machine".x(() =>
+            {
+                var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<string, int>();
+                stateMachineDefinitionBuilder
+                    .In("A")
+                    .On(1)
+                    .Goto("B");
+                stateMachineDefinitionBuilder
+                    .In("B")
+                    .On(2)
+                    .Goto("C");
+                stateMachineDefinitionBuilder
+                    .In("C")
+                    .On(3)
+                    .Goto("A");
+                machine = stateMachineDefinitionBuilder
+                    .WithInitialState("A")
+                    .Build()
+                    .CreateActiveStateMachine();
+            });
+
+            "when events are fired".x(async () =>
+            {
+                await machine.Fire(1);
+                await machine.Fire(2);
+                await machine.FirePriority(3);
+                await machine.FirePriority(4);
+            });
+
+            "and it is saved".x(async () =>
+            {
+                saver = new StateMachineSaver<string, int>();
+                await machine.Save(saver);
+            });
+
+            "it should save those events".x(() =>
+            {
+                saver
+                    .Events
+                    .Select(x => x.EventId)
+                    .Should()
+                    .HaveCount(2)
+                    .And
+                    .ContainInOrder(1, 2);
+                saver
+                    .PriorityEvents
+                    .Select(x => x.EventId)
+                    .Should()
+                    .HaveCount(2)
+                    .And
+                    .ContainInOrder(4, 3);
+            });
+        }
+
+        [Scenario]
+        public void LoadingEventsForActiveStateMachine(
+            AsyncActiveStateMachine<string, int> machine)
+        {
+            "establish a passive state machine".x(() =>
+            {
+                var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<string, int>();
+                stateMachineDefinitionBuilder
+                    .In("A")
+                    .On(1)
+                    .Goto("B");
+                stateMachineDefinitionBuilder
+                    .In("B")
+                    .On(2)
+                    .Goto("C");
+                stateMachineDefinitionBuilder
+                    .In("C")
+                    .On(3)
+                    .Goto("A");
+                machine = stateMachineDefinitionBuilder
+                    .WithInitialState("A")
+                    .Build()
+                    .CreateActiveStateMachine();
+            });
+
+            "when it is loaded with Events".x(async () =>
+            {
+                var loader = new StateMachineLoader<string, int>();
+                loader.SetEvents(new List<EventInformation<int>>
+                {
+                    new EventInformation<int>(2, null),
+                    new EventInformation<int>(3, null),
+                });
+                loader.SetPriorityEvents(new List<EventInformation<int>>
+                {
+                    new EventInformation<int>(1, null)
+                });
+                await machine.Load(loader);
+            });
+
+            "it should process those events".x(async () =>
+            {
+                var transitionRecords = new List<TransitionRecord>();
+                machine.TransitionCompleted += (sender, args) =>
+                    transitionRecords.Add(
+                        new TransitionRecord(args.EventId, args.StateId, args.NewStateId));
+
+                var signal = SetUpWaitForAllTransitions(machine, 3);
+                await machine.Start();
+                WaitForAllTransitions(signal);
+
+                transitionRecords
+                    .Should()
+                    .HaveCount(3)
+                    .And
+                    .IsEquivalentInOrder(new List<TransitionRecord>
+                    {
+                        new TransitionRecord(1, "A", "B"),
+                        new TransitionRecord(2, "B", "C"),
+                        new TransitionRecord(3, "C", "A")
+                    });
             });
         }
 
@@ -192,6 +437,46 @@ namespace Appccelerate.StateMachine.Specs.Async
                     .On(Event.B).Goto(State.B);
         }
 
+        private static AutoResetEvent SetUpWaitForAllTransitions<TState, TEvent>(IAsyncStateMachine<TState, TEvent> testee, int numberOfTransitionCompletedMessages)
+            where TState : IComparable
+            where TEvent : IComparable
+        {
+            var numberOfTransitionCompletedMessagesReceived = 0;
+            var allTransitionsCompleted = new AutoResetEvent(false);
+            testee.TransitionCompleted += (sender, e) =>
+            {
+                numberOfTransitionCompletedMessagesReceived++;
+                if (numberOfTransitionCompletedMessagesReceived == numberOfTransitionCompletedMessages)
+                {
+                    allTransitionsCompleted.Set();
+                }
+            };
+
+            return allTransitionsCompleted;
+        }
+
+        private static void WaitForAllTransitions(AutoResetEvent allTransitionsCompleted)
+        {
+            allTransitionsCompleted.WaitOne(1000)
+                .Should().BeTrue("not enough transition completed events received within time-out.");
+        }
+
+        public class TransitionRecord
+        {
+            public int EventId { get; }
+
+            public string Source { get; }
+
+            public string Destination { get; }
+
+            public TransitionRecord(int eventId, string source, string destination)
+            {
+                this.EventId = eventId;
+                this.Source = source;
+                this.Destination = destination;
+            }
+        }
+
         public class FakeExtension : AsyncExtensionBase<State, Event>
         {
             public List<IInitializable<State>> LoadedCurrentState { get; } = new List<IInitializable<State>>();
@@ -206,12 +491,17 @@ namespace Appccelerate.StateMachine.Specs.Async
             }
         }
 
-        public class StateMachineSaver<TState> : IAsyncStateMachineSaver<TState>
+        public class StateMachineSaver<TState, TEvent> : IAsyncStateMachineSaver<TState, TEvent>
             where TState : IComparable
+            where TEvent : IComparable
         {
             public IInitializable<TState> CurrentStateId { get; private set; }
 
             public IReadOnlyDictionary<TState, TState> HistoryStates { get; private set; }
+
+            public IReadOnlyCollection<EventInformation<TEvent>> Events { get; private set; }
+
+            public IReadOnlyCollection<EventInformation<TEvent>> PriorityEvents { get; private set; }
 
             public Task SaveCurrentState(IInitializable<TState> currentState)
             {
@@ -226,13 +516,28 @@ namespace Appccelerate.StateMachine.Specs.Async
 
                 return Task.CompletedTask;
             }
+
+            public Task SaveEvents(IReadOnlyCollection<EventInformation<TEvent>> events)
+            {
+                this.Events = events;
+                return Task.CompletedTask;
+            }
+
+            public Task SavePriorityEvents(IReadOnlyCollection<EventInformation<TEvent>> priorityEvents)
+            {
+                this.PriorityEvents = priorityEvents;
+                return Task.CompletedTask;
+            }
         }
 
-        public class StateMachineLoader<TState> : IAsyncStateMachineLoader<TState>
+        public class StateMachineLoader<TState, TEvent> : IAsyncStateMachineLoader<TState, TEvent>
             where TState : IComparable
+            where TEvent : IComparable
         {
-            private IInitializable<TState> currentState;
-            private IReadOnlyDictionary<TState, TState> historyStates;
+            private IInitializable<TState> currentState = Initializable<TState>.UnInitialized();
+            private IReadOnlyDictionary<TState, TState> historyStates = new Dictionary<TState, TState>();
+            private IReadOnlyCollection<EventInformation<TEvent>> events = new List<EventInformation<TEvent>>();
+            private IReadOnlyCollection<EventInformation<TEvent>> priorityEvents = new List<EventInformation<TEvent>>();
 
             public void SetCurrentState(IInitializable<TState> state)
             {
@@ -252,6 +557,26 @@ namespace Appccelerate.StateMachine.Specs.Async
             public Task<IInitializable<TState>> LoadCurrentState()
             {
                 return Task.FromResult(this.currentState);
+            }
+
+            public Task<IReadOnlyCollection<EventInformation<TEvent>>> LoadEvents()
+            {
+                return Task.FromResult(this.events);
+            }
+
+            public Task<IReadOnlyCollection<EventInformation<TEvent>>> LoadPriorityEvents()
+            {
+                return Task.FromResult(this.priorityEvents);
+            }
+
+            public void SetEvents(IReadOnlyCollection<EventInformation<TEvent>> events)
+            {
+                this.events = events;
+            }
+
+            public void SetPriorityEvents(IReadOnlyCollection<EventInformation<TEvent>> priorityEvents)
+            {
+                this.priorityEvents = priorityEvents;
             }
         }
     }

--- a/source/Appccelerate.StateMachine.Specs/Async/Persisting.cs
+++ b/source/Appccelerate.StateMachine.Specs/Async/Persisting.cs
@@ -118,7 +118,7 @@ namespace Appccelerate.StateMachine.Specs.Async
             "when a non-initialized state machine is loaded".x(async () =>
             {
                 var loader = new StateMachineLoader<State>();
-                loader.SetCurrentState(new Initializable<State>());
+                loader.SetCurrentState(Initializable<State>.UnInitialized());
                 loader.SetHistoryStates(new Dictionary<State, State>());
 
                 var stateMachineDefinitionBuilder = new StateMachineDefinitionBuilder<State, Event>();

--- a/source/Appccelerate.StateMachine.Specs/EquivalenceExtensions.cs
+++ b/source/Appccelerate.StateMachine.Specs/EquivalenceExtensions.cs
@@ -1,0 +1,51 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="EquivalenceExtensions.cs" company="Appccelerate">
+//   Copyright (c) 2008-2019 Appccelerate
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+namespace Appccelerate.StateMachine.Specs
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using FluentAssertions;
+    using FluentAssertions.Collections;
+
+    public static class EquivalenceExtensions
+    {
+        public static void IsEquivalentInOrder<T>(this GenericCollectionAssertions<T> genericCollectionAssertions, IList<T> other)
+            where T : class
+        {
+            var listToAssert = ConvertOrCastToList(genericCollectionAssertions.Subject);
+
+            listToAssert
+                .Count
+                .Should()
+                .Be(other.Count);
+
+            for (var i = 0; i < listToAssert.Count; i++)
+            {
+                listToAssert[i]
+                    .Should()
+                    .BeEquivalentTo(other[i]);
+            }
+        }
+
+        private static IList<T> ConvertOrCastToList<T>(IEnumerable<T> source)
+        {
+            return source as IList<T> ?? source.ToList();
+        }
+    }
+}

--- a/source/Appccelerate.StateMachine.Specs/Sync/Persisting.cs
+++ b/source/Appccelerate.StateMachine.Specs/Sync/Persisting.cs
@@ -353,7 +353,8 @@ namespace Appccelerate.StateMachine.Specs.Sync
             public override void Loaded(
                 IStateMachineInformation<State, Event> stateMachineInformation,
                 IInitializable<State> loadedCurrentState,
-                IReadOnlyDictionary<State, State> loadedHistoryStates)
+                IReadOnlyDictionary<State, State> loadedHistoryStates,
+                IReadOnlyCollection<EventInformation<Event>> events)
             {
                 this.LoadedCurrentState.Add(loadedCurrentState);
             }

--- a/source/Appccelerate.StateMachine/ActiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/ActiveStateMachine.cs
@@ -163,10 +163,7 @@ namespace Appccelerate.StateMachine
             stateMachineSaver.SaveCurrentState(this.stateContainer.CurrentStateId);
 
             var historyStates = this.stateContainer
-                .LastActiveStates
-                .ToDictionary(
-                    pair => pair.Key,
-                    pair => pair.Value.Id);
+                .LastActiveStates;
 
             stateMachineSaver.SaveHistoryStates(historyStates);
         }
@@ -199,9 +196,14 @@ namespace Appccelerate.StateMachine
                 foreach (var historyState in historyStates)
                 {
                     var superState = this.stateDefinitions[historyState.Key];
-                    var lastActiveState = this.stateDefinitions[historyState.Value];
+                    var lastActiveState = historyState.Value;
 
-                    if (!superState.SubStates.Contains(lastActiveState))
+                    var lastActiveStateIsNotASubStateOfSuperState = superState
+                                                                        .SubStates
+                                                                        .Select(x => x.Id)
+                                                                        .Contains(lastActiveState)
+                                                                    == false;
+                    if (lastActiveStateIsNotASubStateOfSuperState)
                     {
                         throw new InvalidOperationException(ExceptionMessages.CannotSetALastActiveStateThatIsNotASubState);
                     }

--- a/source/Appccelerate.StateMachine/ActiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/ActiveStateMachine.cs
@@ -219,7 +219,8 @@ namespace Appccelerate.StateMachine
                 this.stateContainer.Extensions.ForEach(
                     extension => extension.Loaded(
                         loadedCurrentState,
-                        historyStates));
+                        historyStates,
+                        events));
             }
         }
 

--- a/source/Appccelerate.StateMachine/ActiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/ActiveStateMachine.cs
@@ -191,7 +191,7 @@ namespace Appccelerate.StateMachine
 
             void SetCurrentState()
             {
-                this.stateContainer.CurrentState = loadedCurrentState.Map(x => this.stateDefinitions[x]);
+                this.stateContainer.CurrentStateId = loadedCurrentState;
             }
 
             void LoadHistoryStates()
@@ -345,7 +345,7 @@ namespace Appccelerate.StateMachine
 
         private void InitializeStateMachineIfInitializationIsPending()
         {
-            if (this.stateContainer.CurrentState.IsInitialized)
+            if (this.stateContainer.CurrentStateId.IsInitialized)
             {
                 return;
             }
@@ -355,7 +355,7 @@ namespace Appccelerate.StateMachine
 
         private void CheckThatNotAlreadyInitialized()
         {
-            if (this.stateContainer.CurrentState.IsInitialized)
+            if (this.stateContainer.CurrentStateId.IsInitialized)
             {
                 throw new InvalidOperationException(ExceptionMessages.StateMachineIsAlreadyInitialized);
             }

--- a/source/Appccelerate.StateMachine/AsyncActiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/AsyncActiveStateMachine.cs
@@ -227,7 +227,9 @@ namespace Appccelerate.StateMachine
                 this.stateContainer.Extensions.ForEach(
                     extension => extension.Loaded(
                         loadedCurrentState,
-                        historyStates));
+                        historyStates,
+                        events,
+                        priorityEvents));
             }
         }
 

--- a/source/Appccelerate.StateMachine/AsyncActiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/AsyncActiveStateMachine.cs
@@ -191,7 +191,7 @@ namespace Appccelerate.StateMachine
 
             void SetCurrentState()
             {
-                this.stateContainer.CurrentState = loadedCurrentState.Map(x => this.stateDefinitions[x]);
+                this.stateContainer.CurrentStateId = loadedCurrentState;
             }
 
             void LoadHistoryStates()
@@ -385,7 +385,7 @@ namespace Appccelerate.StateMachine
 
         private void CheckThatNotAlreadyInitialized()
         {
-            if (this.stateContainer.CurrentState.IsInitialized)
+            if (this.stateContainer.CurrentStateId.IsInitialized)
             {
                 throw new InvalidOperationException(ExceptionMessages.StateMachineIsAlreadyInitialized);
             }
@@ -393,7 +393,7 @@ namespace Appccelerate.StateMachine
 
         private async Task InitializeStateMachineIfInitializationIsPending()
         {
-            if (this.stateContainer.CurrentState.IsInitialized)
+            if (this.stateContainer.CurrentStateId.IsInitialized)
             {
                 return;
             }

--- a/source/Appccelerate.StateMachine/AsyncActiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/AsyncActiveStateMachine.cs
@@ -118,7 +118,7 @@ namespace Appccelerate.StateMachine
             this.events.Enqueue(new EventInformation<TEvent>(eventId, eventArgument));
 
             await this.stateContainer
-                .ForEach(extension => extension.EventQueued(this.stateContainer, eventId, eventArgument))
+                .ForEach(extension => extension.EventQueued(eventId, eventArgument))
                 .ConfigureAwait(false);
 
             this.workerCompletionSource.TrySetResult(true);
@@ -145,7 +145,7 @@ namespace Appccelerate.StateMachine
             this.priorityEvents.Push(new EventInformation<TEvent>(eventId, eventArgument));
 
             await this.stateContainer
-                .ForEach(extension => extension.EventQueuedWithPriority(this.stateContainer, eventId, eventArgument))
+                .ForEach(extension => extension.EventQueuedWithPriority(eventId, eventArgument))
                 .ConfigureAwait(false);
 
             this.workerCompletionSource.TrySetResult(true);
@@ -216,7 +216,6 @@ namespace Appccelerate.StateMachine
             {
                 this.stateContainer.Extensions.ForEach(
                     extension => extension.Loaded(
-                        this.stateContainer,
                         loadedCurrentState,
                         historyStates));
             }
@@ -241,7 +240,7 @@ namespace Appccelerate.StateMachine
                 CancellationToken.None);
 
             await this.stateContainer
-                .ForEach(extension => extension.StartedStateMachine(this.stateContainer))
+                .ForEach(extension => extension.StartedStateMachine())
                 .ConfigureAwait(false);
         }
 
@@ -282,7 +281,6 @@ namespace Appccelerate.StateMachine
                         eventInformation.EventId,
                         eventInformation.EventArgument,
                         this.stateContainer,
-                        this.stateContainer,
                         this.stateDefinitions)
                     .ConfigureAwait(false);
 
@@ -309,7 +307,6 @@ namespace Appccelerate.StateMachine
                 await this.stateMachine.Fire(
                         eventInformation.EventId,
                         eventInformation.EventArgument,
-                        this.stateContainer,
                         this.stateContainer,
                         this.stateDefinitions)
                     .ConfigureAwait(false);
@@ -341,7 +338,7 @@ namespace Appccelerate.StateMachine
             }
 
             await this.stateContainer
-                .ForEach(extension => extension.StoppedStateMachine(this.stateContainer))
+                .ForEach(extension => extension.StoppedStateMachine())
                 .ConfigureAwait(false);
         }
 
@@ -351,7 +348,8 @@ namespace Appccelerate.StateMachine
         /// <param name="extension">The extension.</param>
         public void AddExtension(IExtension<TState, TEvent> extension)
         {
-            this.stateContainer.Extensions.Add(extension);
+            var extensionCompose = new InternalExtension<TState, TEvent>(extension, this.stateContainer);
+            this.stateContainer.Extensions.Add(extensionCompose);
         }
 
         /// <summary>
@@ -398,7 +396,7 @@ namespace Appccelerate.StateMachine
             }
 
             await this.stateMachine
-                .EnterInitialState(this.stateContainer, this.stateContainer, this.stateDefinitions, this.initialState)
+                .EnterInitialState(this.stateContainer, this.stateDefinitions, this.initialState)
                 .ConfigureAwait(false);
         }
     }

--- a/source/Appccelerate.StateMachine/AsyncActiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/AsyncActiveStateMachine.cs
@@ -164,10 +164,8 @@ namespace Appccelerate.StateMachine
                 .ConfigureAwait(false);
 
             var historyStates = this.stateContainer
-                .LastActiveStates
-                .ToDictionary(
-                    pair => pair.Key,
-                    pair => pair.Value.Id);
+                .LastActiveStates;
+
             await stateMachineSaver.SaveHistoryStates(historyStates)
                 .ConfigureAwait(false);
         }
@@ -201,9 +199,14 @@ namespace Appccelerate.StateMachine
                 foreach (var historyState in historyStates)
                 {
                     var superState = this.stateDefinitions[historyState.Key];
-                    var lastActiveState = this.stateDefinitions[historyState.Value];
+                    var lastActiveState = historyState.Value;
 
-                    if (!superState.SubStates.Contains(lastActiveState))
+                    var lastActiveStateIsNotASubStateOfSuperState = superState
+                                                                        .SubStates
+                                                                        .Select(x => x.Id)
+                                                                        .Contains(lastActiveState)
+                                                                    == false;
+                    if (lastActiveStateIsNotASubStateOfSuperState)
                     {
                         throw new InvalidOperationException(ExceptionMessages.CannotSetALastActiveStateThatIsNotASubState);
                     }

--- a/source/Appccelerate.StateMachine/AsyncMachine/AsyncExtensionBase.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/AsyncExtensionBase.cs
@@ -293,11 +293,12 @@ namespace Appccelerate.StateMachine.AsyncMachine
             return TaskEx.Completed;
         }
 
-        public virtual void Loaded(
+        public virtual Task Loaded(
             IStateMachineInformation<TState, TEvent> stateMachineInformation,
             IInitializable<TState> loadedCurrentState,
             IReadOnlyDictionary<TState, TState> loadedHistoryStates)
         {
+            return TaskEx.Completed;
         }
     }
 }

--- a/source/Appccelerate.StateMachine/AsyncMachine/AsyncExtensionBase.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/AsyncExtensionBase.cs
@@ -296,7 +296,9 @@ namespace Appccelerate.StateMachine.AsyncMachine
         public virtual Task Loaded(
             IStateMachineInformation<TState, TEvent> stateMachineInformation,
             IInitializable<TState> loadedCurrentState,
-            IReadOnlyDictionary<TState, TState> loadedHistoryStates)
+            IReadOnlyDictionary<TState, TState> loadedHistoryStates,
+            IReadOnlyCollection<EventInformation<TEvent>> events,
+            IReadOnlyCollection<EventInformation<TEvent>> priorityEvents)
         {
             return TaskEx.Completed;
         }

--- a/source/Appccelerate.StateMachine/AsyncMachine/HierarchyBuilder.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/HierarchyBuilder.cs
@@ -33,12 +33,12 @@ namespace Appccelerate.StateMachine.AsyncMachine
         private readonly StateDefinition<TState, TEvent> superState;
 
         private readonly IImplicitAddIfNotAvailableStateDefinitionDictionary<TState, TEvent> stateDefinitions;
-        private readonly IDictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates;
+        private readonly IDictionary<TState, TState> initiallyLastActiveStates;
 
         public HierarchyBuilder(
             TState superStateId,
             IImplicitAddIfNotAvailableStateDefinitionDictionary<TState, TEvent> stateDefinitions,
-            IDictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates)
+            IDictionary<TState, TState> initiallyLastActiveStates)
         {
             Guard.AgainstNullArgument("states", stateDefinitions);
 
@@ -59,7 +59,7 @@ namespace Appccelerate.StateMachine.AsyncMachine
             this.WithSubState(stateId);
 
             this.superState.InitialStateModifiable = this.stateDefinitions[stateId];
-            this.initiallyLastActiveStates.Add(this.superState.Id, this.stateDefinitions[stateId]);
+            this.initiallyLastActiveStates.Add(this.superState.Id, stateId);
 
             return this;
         }

--- a/source/Appccelerate.StateMachine/AsyncMachine/IExtension.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/IExtension.cs
@@ -273,6 +273,8 @@ namespace Appccelerate.StateMachine.AsyncMachine
         Task Loaded(
             IStateMachineInformation<TState, TEvent> stateMachineInformation,
             IInitializable<TState> loadedCurrentState,
-            IReadOnlyDictionary<TState, TState> loadedHistoryStates);
+            IReadOnlyDictionary<TState, TState> loadedHistoryStates,
+            IReadOnlyCollection<EventInformation<TEvent>> events,
+            IReadOnlyCollection<EventInformation<TEvent>> priorityEvents);
     }
 }

--- a/source/Appccelerate.StateMachine/AsyncMachine/IExtension.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/IExtension.cs
@@ -270,7 +270,7 @@ namespace Appccelerate.StateMachine.AsyncMachine
             IStateDefinition<TState, TEvent> state,
             ITransitionContext<TState, TEvent> context);
 
-        void Loaded(
+        Task Loaded(
             IStateMachineInformation<TState, TEvent> stateMachineInformation,
             IInitializable<TState> loadedCurrentState,
             IReadOnlyDictionary<TState, TState> loadedHistoryStates);

--- a/source/Appccelerate.StateMachine/AsyncMachine/IExtensionHost.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/IExtensionHost.cs
@@ -35,6 +35,6 @@ namespace Appccelerate.StateMachine.AsyncMachine
         /// </summary>
         /// <param name="action">The action to execute.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task ForEach(Func<IExtension<TState, TEvent>, Task> action);
+        Task ForEach(Func<IExtensionInternal<TState, TEvent>, Task> action);
     }
 }

--- a/source/Appccelerate.StateMachine/AsyncMachine/IExtensionInternal.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/IExtensionInternal.cs
@@ -103,7 +103,9 @@ namespace Appccelerate.StateMachine.AsyncMachine
 
         Task Loaded(
             IInitializable<TState> loadedCurrentState,
-            IReadOnlyDictionary<TState, TState> loadedHistoryStates);
+            IReadOnlyDictionary<TState, TState> loadedHistoryStates,
+            IReadOnlyCollection<EventInformation<TEvent>> events,
+            IReadOnlyCollection<EventInformation<TEvent>> priorityEvents);
 
         Task EnteringState(
             IStateDefinition<TState, TEvent> stateDefinition,

--- a/source/Appccelerate.StateMachine/AsyncMachine/IExtensionInternal.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/IExtensionInternal.cs
@@ -16,10 +16,11 @@
 // </copyright>
 //-------------------------------------------------------------------------------
 
-namespace Appccelerate.StateMachine.Machine
+namespace Appccelerate.StateMachine.AsyncMachine
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Infrastructure;
     using States;
     using Transitions;
@@ -28,83 +29,83 @@ namespace Appccelerate.StateMachine.Machine
         where TState : IComparable
         where TEvent : IComparable
     {
-        void StartedStateMachine();
+        Task StartedStateMachine();
 
-        void StoppedStateMachine();
+        Task StoppedStateMachine();
 
-        void EventQueued(TEvent eventId, object eventArgument);
+        Task EventQueued(TEvent eventId, object eventArgument);
 
-        void EventQueuedWithPriority(TEvent eventId, object eventArgument);
+        Task EventQueuedWithPriority(TEvent eventId, object eventArgument);
 
-        void SwitchedState(IStateDefinition<TState, TEvent> oldState, IStateDefinition<TState, TEvent> newState);
+        Task SwitchedState(IStateDefinition<TState, TEvent> oldState, IStateDefinition<TState, TEvent> newState);
 
-        void EnteringInitialState(TState state);
+        Task EnteringInitialState(TState state);
 
-        void EnteredInitialState(TState state, ITransitionContext<TState, TEvent> context);
+        Task EnteredInitialState(TState state, ITransitionContext<TState, TEvent> context);
 
-        void FiringEvent(
+        Task FiringEvent(
             ref TEvent eventId,
             ref object eventArgument);
 
-        void FiredEvent(ITransitionContext<TState, TEvent> context);
+        Task FiredEvent(ITransitionContext<TState, TEvent> context);
 
-        void HandlingEntryActionException(
+        Task HandlingEntryActionException(
             IStateDefinition<TState, TEvent> stateDefinition,
             ITransitionContext<TState, TEvent> context,
             ref Exception exception);
 
-        void HandledEntryActionException(
+        Task HandledEntryActionException(
             IStateDefinition<TState, TEvent> stateDefinition,
             ITransitionContext<TState, TEvent> context,
             Exception exception);
 
-        void HandlingExitActionException(
+        Task HandlingExitActionException(
             IStateDefinition<TState, TEvent> stateDefinition,
             ITransitionContext<TState, TEvent> context,
             ref Exception exception);
 
-        void HandledExitActionException(
+        Task HandledExitActionException(
             IStateDefinition<TState, TEvent> stateDefinition,
             ITransitionContext<TState, TEvent> context,
             Exception exception);
 
-        void HandlingGuardException(
+        Task HandlingGuardException(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> transitionContext,
             ref Exception exception);
 
-        void HandledGuardException(
+        Task HandledGuardException(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> transitionContext,
             Exception exception);
 
-        void HandlingTransitionException(
+        Task HandlingTransitionException(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> context,
             ref Exception exception);
 
-        void HandledTransitionException(
+        Task HandledTransitionException(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> transitionContext,
             Exception exception);
 
-        void SkippedTransition(
+        Task SkippedTransition(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> context);
 
-        void ExecutingTransition(
+        Task ExecutingTransition(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> context);
 
-        void ExecutedTransition(
+        Task ExecutedTransition(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> context);
 
-        void Loaded(
+        Task Loaded(
             IInitializable<TState> loadedCurrentState,
             IReadOnlyDictionary<TState, TState> loadedHistoryStates);
 
-        void EnteringState(
+        Task EnteringState(
             IStateDefinition<TState, TEvent> stateDefinition,
             ITransitionContext<TState, TEvent> context);
     }

--- a/source/Appccelerate.StateMachine/AsyncMachine/ILastActiveStateModifier.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/ILastActiveStateModifier.cs
@@ -19,14 +19,13 @@
 namespace Appccelerate.StateMachine.AsyncMachine
 {
     using System;
-    using States;
+    using Infrastructure;
 
-    public interface ILastActiveStateModifier<TState, TEvent>
+    public interface ILastActiveStateModifier<TState>
         where TState : IComparable
-        where TEvent : IComparable
     {
-        IStateDefinition<TState, TEvent> GetLastActiveStateOrNullFor(TState state);
+        Optional<TState> GetLastActiveStateFor(TState state);
 
-        void SetLastActiveStateFor(TState state, IStateDefinition<TState, TEvent> newLastActiveState);
+        void SetLastActiveStateFor(TState state, TState newLastActiveState);
     }
 }

--- a/source/Appccelerate.StateMachine/AsyncMachine/InternalExtension.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/InternalExtension.cs
@@ -172,9 +172,11 @@ namespace Appccelerate.StateMachine.AsyncMachine
 
         public Task Loaded(
             IInitializable<TState> loadedCurrentState,
-            IReadOnlyDictionary<TState, TState> loadedHistoryStates)
+            IReadOnlyDictionary<TState, TState> loadedHistoryStates,
+            IReadOnlyCollection<EventInformation<TEvent>> events,
+            IReadOnlyCollection<EventInformation<TEvent>> priorityEvents)
         {
-            return this.apiExtension.Loaded(this.stateMachineInformation, loadedCurrentState, loadedHistoryStates);
+            return this.apiExtension.Loaded(this.stateMachineInformation, loadedCurrentState, loadedHistoryStates, events, priorityEvents);
         }
 
         public Task EnteringState(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context)

--- a/source/Appccelerate.StateMachine/AsyncMachine/InternalExtension.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/InternalExtension.cs
@@ -1,0 +1,185 @@
+//-------------------------------------------------------------------------------
+// <copyright file="InternalExtension.cs" company="Appccelerate">
+//   Copyright (c) 2008-2019 Appccelerate
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+namespace Appccelerate.StateMachine.AsyncMachine
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Infrastructure;
+    using States;
+    using Transitions;
+
+    public class InternalExtension<TState, TEvent> : IExtensionInternal<TState, TEvent>
+        where TState : IComparable
+        where TEvent : IComparable
+    {
+        private readonly IExtension<TState, TEvent> apiExtension;
+        private readonly IStateMachineInformation<TState, TEvent> stateMachineInformation;
+
+        public InternalExtension(
+            IExtension<TState, TEvent> apiExtension,
+            IStateMachineInformation<TState, TEvent> stateMachineInformation)
+        {
+            this.apiExtension = apiExtension;
+            this.stateMachineInformation = stateMachineInformation;
+        }
+
+        public Task StartedStateMachine()
+        {
+            return this.apiExtension.StartedStateMachine(this.stateMachineInformation);
+        }
+
+        public Task StoppedStateMachine()
+        {
+            return this.apiExtension.StoppedStateMachine(this.stateMachineInformation);
+        }
+
+        public Task EventQueued(TEvent eventId, object eventArgument)
+        {
+            return this.apiExtension.EventQueued(this.stateMachineInformation, eventId, eventArgument);
+        }
+
+        public Task EventQueuedWithPriority(TEvent eventId, object eventArgument)
+        {
+            return this.apiExtension.EventQueuedWithPriority(this.stateMachineInformation, eventId, eventArgument);
+        }
+
+        public Task SwitchedState(IStateDefinition<TState, TEvent> oldState, IStateDefinition<TState, TEvent> newState)
+        {
+            return this.apiExtension.SwitchedState(this.stateMachineInformation, oldState, newState);
+        }
+
+        public Task EnteringInitialState(TState state)
+        {
+            return this.apiExtension.EnteringInitialState(this.stateMachineInformation, state);
+        }
+
+        public Task EnteredInitialState(TState state, ITransitionContext<TState, TEvent> context)
+        {
+            return this.apiExtension.EnteredInitialState(this.stateMachineInformation, state, context);
+        }
+
+        public Task FiringEvent(ref TEvent eventId, ref object eventArgument)
+        {
+            return this.apiExtension.FiringEvent(this.stateMachineInformation, ref eventId, ref eventArgument);
+        }
+
+        public Task FiredEvent(ITransitionContext<TState, TEvent> context)
+        {
+            return this.apiExtension.FiredEvent(this.stateMachineInformation, context);
+        }
+
+        public Task HandlingEntryActionException(
+            IStateDefinition<TState, TEvent> stateDefinition,
+            ITransitionContext<TState, TEvent> context,
+            ref Exception exception)
+        {
+            return this.apiExtension.HandlingEntryActionException(this.stateMachineInformation, stateDefinition, context, ref exception);
+        }
+
+        public Task HandledEntryActionException(
+            IStateDefinition<TState, TEvent> stateDefinition,
+            ITransitionContext<TState, TEvent> context,
+            Exception exception)
+        {
+            return this.apiExtension.HandledEntryActionException(this.stateMachineInformation, stateDefinition, context, exception);
+        }
+
+        public Task HandlingExitActionException(
+            IStateDefinition<TState, TEvent> stateDefinition,
+            ITransitionContext<TState, TEvent> context,
+            ref Exception exception)
+        {
+            return this.apiExtension.HandlingExitActionException(this.stateMachineInformation, stateDefinition, context, ref exception);
+        }
+
+        public Task HandledExitActionException(
+            IStateDefinition<TState, TEvent> stateDefinition,
+            ITransitionContext<TState, TEvent> context,
+            Exception exception)
+        {
+            return this.apiExtension.HandledExitActionException(this.stateMachineInformation, stateDefinition, context, exception);
+        }
+
+        public Task HandlingGuardException(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext,
+            ref Exception exception)
+        {
+            return this.apiExtension.HandlingGuardException(this.stateMachineInformation, transitionDefinition, transitionContext, ref exception);
+        }
+
+        public Task HandledGuardException(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext,
+            Exception exception)
+        {
+            return this.apiExtension.HandledGuardException(this.stateMachineInformation, transitionDefinition, transitionContext, exception);
+        }
+
+        public Task HandlingTransitionException(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> context,
+            ref Exception exception)
+        {
+            return this.apiExtension.HandlingTransitionException(this.stateMachineInformation, transitionDefinition, context, ref exception);
+        }
+
+        public Task HandledTransitionException(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext,
+            Exception exception)
+        {
+            return this.apiExtension.HandledTransitionException(this.stateMachineInformation, transitionDefinition, transitionContext, exception);
+        }
+
+        public Task SkippedTransition(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> context)
+        {
+            return this.apiExtension.SkippedTransition(this.stateMachineInformation, transitionDefinition, context);
+        }
+
+        public Task ExecutingTransition(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext)
+        {
+            return this.apiExtension.ExecutingTransition(this.stateMachineInformation, transitionDefinition, transitionContext);
+        }
+
+        public Task ExecutedTransition(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext)
+        {
+            return this.apiExtension.ExecutedTransition(this.stateMachineInformation, transitionDefinition, transitionContext);
+        }
+
+        public Task Loaded(
+            IInitializable<TState> loadedCurrentState,
+            IReadOnlyDictionary<TState, TState> loadedHistoryStates)
+        {
+            return this.apiExtension.Loaded(this.stateMachineInformation, loadedCurrentState, loadedHistoryStates);
+        }
+
+        public Task EnteringState(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context)
+        {
+            return this.apiExtension.EnteringState(this.stateMachineInformation, stateDefinition, context);
+        }
+    }
+}

--- a/source/Appccelerate.StateMachine/AsyncMachine/InternalExtensionBase.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/InternalExtensionBase.cs
@@ -16,137 +16,159 @@
 // </copyright>
 //-------------------------------------------------------------------------------
 
-namespace Appccelerate.StateMachine.Extensions
+namespace Appccelerate.StateMachine.AsyncMachine
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Infrastructure;
-    using Machine;
-    using Machine.States;
-    using Machine.Transitions;
+    using States;
+    using Transitions;
 
     public class InternalExtensionBase<TState, TEvent> : IExtensionInternal<TState, TEvent>
         where TState : IComparable
         where TEvent : IComparable
     {
-        public virtual void StartedStateMachine()
+        public virtual Task StartedStateMachine()
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void StoppedStateMachine()
+        public virtual Task StoppedStateMachine()
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void EventQueued(TEvent eventId, object eventArgument)
+        public virtual Task EventQueued(TEvent eventId, object eventArgument)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void EventQueuedWithPriority(TEvent eventId, object eventArgument)
+        public virtual Task EventQueuedWithPriority(TEvent eventId, object eventArgument)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void SwitchedState(IStateDefinition<TState, TEvent> oldState, IStateDefinition<TState, TEvent> newState)
+        public virtual Task SwitchedState(IStateDefinition<TState, TEvent> oldState, IStateDefinition<TState, TEvent> newState)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void EnteringInitialState(TState state)
+        public virtual Task EnteringInitialState(TState state)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void EnteredInitialState(TState state, ITransitionContext<TState, TEvent> context)
+        public virtual Task EnteredInitialState(TState state, ITransitionContext<TState, TEvent> context)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void FiringEvent(ref TEvent eventId, ref object eventArgument)
+        public virtual Task FiringEvent(ref TEvent eventId, ref object eventArgument)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void FiredEvent(ITransitionContext<TState, TEvent> context)
+        public virtual Task FiredEvent(ITransitionContext<TState, TEvent> context)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void HandlingEntryActionException(
+        public virtual Task HandlingEntryActionException(
             IStateDefinition<TState, TEvent> stateDefinition,
             ITransitionContext<TState, TEvent> context,
             ref Exception exception)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void HandledEntryActionException(
+        public virtual Task HandledEntryActionException(
             IStateDefinition<TState, TEvent> stateDefinition,
             ITransitionContext<TState, TEvent> context,
             Exception exception)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void HandlingExitActionException(
+        public virtual Task HandlingExitActionException(
             IStateDefinition<TState, TEvent> stateDefinition,
             ITransitionContext<TState, TEvent> context,
             ref Exception exception)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void HandledExitActionException(
+        public virtual Task HandledExitActionException(
             IStateDefinition<TState, TEvent> stateDefinition,
             ITransitionContext<TState, TEvent> context,
             Exception exception)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void HandlingGuardException(
+        public virtual Task HandlingGuardException(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> transitionContext,
             ref Exception exception)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void HandledGuardException(
+        public virtual Task HandledGuardException(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> transitionContext,
             Exception exception)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void HandlingTransitionException(
+        public virtual Task HandlingTransitionException(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> context,
             ref Exception exception)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void HandledTransitionException(
+        public virtual Task HandledTransitionException(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> transitionContext,
             Exception exception)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void SkippedTransition(
+        public virtual Task SkippedTransition(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> context)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void ExecutingTransition(
+        public virtual Task ExecutingTransition(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> transitionContext)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void ExecutedTransition(
+        public virtual Task ExecutedTransition(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> transitionContext)
         {
+            return TaskEx.Completed;
         }
 
-        public virtual void Loaded(
+        public virtual Task Loaded(
             IInitializable<TState> loadedCurrentState,
             IReadOnlyDictionary<TState, TState> loadedHistoryStates)
         {
+            return TaskEx.Completed;
         }
 
-        public void EnteringState(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context)
+        public Task EnteringState(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context)
         {
+            return TaskEx.Completed;
         }
     }
 }

--- a/source/Appccelerate.StateMachine/AsyncMachine/InternalExtensionBase.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/InternalExtensionBase.cs
@@ -161,7 +161,9 @@ namespace Appccelerate.StateMachine.AsyncMachine
 
         public virtual Task Loaded(
             IInitializable<TState> loadedCurrentState,
-            IReadOnlyDictionary<TState, TState> loadedHistoryStates)
+            IReadOnlyDictionary<TState, TState> loadedHistoryStates,
+            IReadOnlyCollection<EventInformation<TEvent>> events,
+            IReadOnlyCollection<EventInformation<TEvent>> priorityEvents)
         {
             return TaskEx.Completed;
         }

--- a/source/Appccelerate.StateMachine/AsyncMachine/StateContainer.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/StateContainer.cs
@@ -52,9 +52,13 @@ namespace Appccelerate.StateMachine.AsyncMachine
 
         public IReadOnlyDictionary<TState, TState> LastActiveStates => this.lastActiveStates;
 
-        public ConcurrentQueue<EventInformation<TEvent>> Events { get; } = new ConcurrentQueue<EventInformation<TEvent>>();
+        public ConcurrentQueue<EventInformation<TEvent>> Events { get; set; } = new ConcurrentQueue<EventInformation<TEvent>>();
 
-        public ConcurrentStack<EventInformation<TEvent>> PriorityEvents { get; } = new ConcurrentStack<EventInformation<TEvent>>();
+        public IReadOnlyCollection<EventInformation<TEvent>> SaveableEvents => new List<EventInformation<TEvent>>(this.Events);
+
+        public ConcurrentStack<EventInformation<TEvent>> PriorityEvents { get; set; } = new ConcurrentStack<EventInformation<TEvent>>();
+
+        public IReadOnlyCollection<EventInformation<TEvent>> SaveablePriorityEvents => new List<EventInformation<TEvent>>(this.PriorityEvents);
 
         public async Task ForEach(Func<IExtensionInternal<TState, TEvent>, Task> action)
         {

--- a/source/Appccelerate.StateMachine/AsyncMachine/StateContainer.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/StateContainer.cs
@@ -46,7 +46,7 @@ namespace Appccelerate.StateMachine.AsyncMachine
 
         public string Name { get; }
 
-        public List<IExtension<TState, TEvent>> Extensions { get; } = new List<IExtension<TState, TEvent>>();
+        public List<IExtensionInternal<TState, TEvent>> Extensions { get; } = new List<IExtensionInternal<TState, TEvent>>();
 
         public Initializable<IStateDefinition<TState, TEvent>> CurrentState { get; set; }
 
@@ -54,7 +54,7 @@ namespace Appccelerate.StateMachine.AsyncMachine
 
         public IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> LastActiveStates => this.lastActiveStates;
 
-        public async Task ForEach(Func<IExtension<TState, TEvent>, Task> action)
+        public async Task ForEach(Func<IExtensionInternal<TState, TEvent>, Task> action)
         {
             foreach (var extension in this.Extensions)
             {

--- a/source/Appccelerate.StateMachine/AsyncMachine/StateContainer.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/StateContainer.cs
@@ -27,11 +27,11 @@ namespace Appccelerate.StateMachine.AsyncMachine
     public class StateContainer<TState, TEvent> :
         IExtensionHost<TState, TEvent>,
         IStateMachineInformation<TState, TEvent>,
-        ILastActiveStateModifier<TState, TEvent>
+        ILastActiveStateModifier<TState>
         where TState : IComparable
         where TEvent : IComparable
     {
-        private readonly Dictionary<TState, IStateDefinition<TState, TEvent>> lastActiveStates = new Dictionary<TState, IStateDefinition<TState, TEvent>>();
+        private readonly Dictionary<TState, TState> lastActiveStates = new Dictionary<TState, TState>();
 
         public StateContainer()
             : this(default(string))
@@ -52,7 +52,7 @@ namespace Appccelerate.StateMachine.AsyncMachine
 
         public IInitializable<TState> CurrentStateId => this.CurrentState.Map(x => x.Id);
 
-        public IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> LastActiveStates => this.lastActiveStates;
+        public IReadOnlyDictionary<TState, TState> LastActiveStates => this.lastActiveStates;
 
         public async Task ForEach(Func<IExtensionInternal<TState, TEvent>, Task> action)
         {
@@ -63,13 +63,15 @@ namespace Appccelerate.StateMachine.AsyncMachine
             }
         }
 
-        public IStateDefinition<TState, TEvent> GetLastActiveStateOrNullFor(TState state)
+        public Optional<TState> GetLastActiveStateFor(TState state)
         {
-            this.lastActiveStates.TryGetValue(state, out var lastActiveState);
-            return lastActiveState;
+            return
+                this.lastActiveStates.TryGetValue(state, out var lastActiveState)
+                    ? Optional<TState>.Just(lastActiveState)
+                    : Optional<TState>.Nothing();
         }
 
-        public void SetLastActiveStateFor(TState state, IStateDefinition<TState, TEvent> newLastActiveState)
+        public void SetLastActiveStateFor(TState state, TState newLastActiveState)
         {
             if (this.lastActiveStates.ContainsKey(state))
             {

--- a/source/Appccelerate.StateMachine/AsyncMachine/StateContainer.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/StateContainer.cs
@@ -41,16 +41,14 @@ namespace Appccelerate.StateMachine.AsyncMachine
         public StateContainer(string name)
         {
             this.Name = name;
-            this.CurrentState = Initializable<IStateDefinition<TState, TEvent>>.UnInitialized();
+            this.CurrentStateId = Initializable<TState>.UnInitialized();
         }
 
         public string Name { get; }
 
         public List<IExtensionInternal<TState, TEvent>> Extensions { get; } = new List<IExtensionInternal<TState, TEvent>>();
 
-        public Initializable<IStateDefinition<TState, TEvent>> CurrentState { get; set; }
-
-        public IInitializable<TState> CurrentStateId => this.CurrentState.Map(x => x.Id);
+        public IInitializable<TState> CurrentStateId { get; set; }
 
         public IReadOnlyDictionary<TState, TState> LastActiveStates => this.lastActiveStates;
 

--- a/source/Appccelerate.StateMachine/AsyncMachine/StateContainer.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/StateContainer.cs
@@ -19,10 +19,10 @@
 namespace Appccelerate.StateMachine.AsyncMachine
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Infrastructure;
-    using States;
 
     public class StateContainer<TState, TEvent> :
         IExtensionHost<TState, TEvent>,
@@ -51,6 +51,10 @@ namespace Appccelerate.StateMachine.AsyncMachine
         public IInitializable<TState> CurrentStateId { get; set; }
 
         public IReadOnlyDictionary<TState, TState> LastActiveStates => this.lastActiveStates;
+
+        public ConcurrentQueue<EventInformation<TEvent>> Events { get; } = new ConcurrentQueue<EventInformation<TEvent>>();
+
+        public ConcurrentStack<EventInformation<TEvent>> PriorityEvents { get; } = new ConcurrentStack<EventInformation<TEvent>>();
 
         public async Task ForEach(Func<IExtensionInternal<TState, TEvent>, Task> action)
         {

--- a/source/Appccelerate.StateMachine/AsyncMachine/StateMachine.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/StateMachine.cs
@@ -70,8 +70,7 @@ namespace Appccelerate.StateMachine.AsyncMachine
 
         private static async Task SwitchStateTo(
             IStateDefinition<TState, TEvent> newState,
-            StateContainer<TState, TEvent> stateContainer,
-            IStateMachineInformation<TState, TEvent> stateMachineInformation)
+            StateContainer<TState, TEvent> stateContainer)
         {
             var oldState = stateContainer.CurrentState.ExtractOr(null);
 
@@ -79,7 +78,7 @@ namespace Appccelerate.StateMachine.AsyncMachine
 
             await stateContainer
                 .ForEach(extension =>
-                    extension.SwitchedState(stateMachineInformation, oldState, newState))
+                    extension.SwitchedState(oldState, newState))
                 .ConfigureAwait(false);
         }
 
@@ -87,24 +86,22 @@ namespace Appccelerate.StateMachine.AsyncMachine
         /// Enters the initial state as specified with <paramref name="initialState"/>.
         /// </summary>
         /// <param name="stateContainer">Contains all mutable state of of the state machine.</param>
-        /// <param name="stateMachineInformation">The state machine information.</param>
         /// <param name="stateDefinitions">The definitions for all states of this state Machine.</param>
         /// <param name="initialState">The initial state the state machine should enter.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task EnterInitialState(
             StateContainer<TState, TEvent> stateContainer,
-            IStateMachineInformation<TState, TEvent> stateMachineInformation,
             IStateDefinitionDictionary<TState, TEvent> stateDefinitions,
             TState initialState)
         {
-            await stateContainer.ForEach(extension => extension.EnteringInitialState(stateMachineInformation, initialState))
+            await stateContainer.ForEach(extension => extension.EnteringInitialState(initialState))
                 .ConfigureAwait(false);
 
             var context = this.factory.CreateTransitionContext(null, new Missable<TEvent>(), Missing.Value, this);
-            await this.EnterInitialState(context, stateContainer, stateMachineInformation, stateDefinitions, initialState)
+            await this.EnterInitialState(context, stateContainer, stateDefinitions, initialState)
                 .ConfigureAwait(false);
 
-            await stateContainer.ForEach(extension => extension.EnteredInitialState(stateMachineInformation, initialState, context))
+            await stateContainer.ForEach(extension => extension.EnteredInitialState(initialState, context))
                 .ConfigureAwait(false);
         }
 
@@ -114,19 +111,17 @@ namespace Appccelerate.StateMachine.AsyncMachine
         /// <param name="eventId">The event.</param>
         /// <param name="eventArgument">The event argument.</param>
         /// <param name="stateContainer">Contains all mutable state of of the state machine.</param>
-        /// <param name="stateMachineInformation">The state machine information.</param>
         /// <param name="stateDefinitions">The definitions for all states of this state Machine.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task Fire(
             TEvent eventId,
             object eventArgument,
             StateContainer<TState, TEvent> stateContainer,
-            IStateMachineInformation<TState, TEvent> stateMachineInformation,
             IStateDefinitionDictionary<TState, TEvent> stateDefinitions)
         {
             CheckThatStateMachineHasEnteredInitialState(stateContainer);
 
-            await stateContainer.ForEach(extension => extension.FiringEvent(stateMachineInformation, ref eventId, ref eventArgument))
+            await stateContainer.ForEach(extension => extension.FiringEvent(ref eventId, ref eventArgument))
                 .ConfigureAwait(false);
 
             var currentState = stateContainer.CurrentState.ExtractOrThrow();
@@ -141,13 +136,13 @@ namespace Appccelerate.StateMachine.AsyncMachine
             }
 
             var newState = stateDefinitions[result.NewState];
-            await SwitchStateTo(newState, stateContainer, stateMachineInformation)
+            await SwitchStateTo(newState, stateContainer)
                 .ConfigureAwait(false);
 
-            await stateContainer.ForEach(extension => extension.FiredEvent(stateMachineInformation, context))
+            await stateContainer.ForEach(extension => extension.FiredEvent(context))
                 .ConfigureAwait(false);
 
-            this.OnTransitionCompleted(context, stateMachineInformation);
+            this.OnTransitionCompleted(context, stateContainer.CurrentStateId.ExtractOrThrow());
         }
 
         public void OnExceptionThrown(ITransitionContext<TState, TEvent> context, Exception exception)
@@ -185,17 +180,12 @@ namespace Appccelerate.StateMachine.AsyncMachine
             this.RaiseEvent(this.TransitionDeclined, new TransitionEventArgs<TState, TEvent>(transitionContext), transitionContext, true);
         }
 
-        /// <summary>
-        /// Fires the <see cref="TransitionCompleted"/> event.
-        /// </summary>
-        /// <param name="transitionContext">The transition event context.</param>
-        /// <param name="stateMachineInformation">The state machine information.</param>
-        private void OnTransitionCompleted(ITransitionContext<TState, TEvent> transitionContext, IStateMachineInformation<TState, TEvent> stateMachineInformation)
+        private void OnTransitionCompleted(ITransitionContext<TState, TEvent> transitionContext, TState currentStateId)
         {
             this.RaiseEvent(
                 this.TransitionCompleted,
                 new TransitionCompletedEventArgs<TState, TEvent>(
-                    stateMachineInformation.CurrentStateId.ExtractOrThrow(),
+                    currentStateId,
                     transitionContext),
                 transitionContext,
                 true);
@@ -204,7 +194,6 @@ namespace Appccelerate.StateMachine.AsyncMachine
         private async Task EnterInitialState(
             ITransitionContext<TState, TEvent> context,
             StateContainer<TState, TEvent> stateContainer,
-            IStateMachineInformation<TState, TEvent> stateMachineInformation,
             IStateDefinitionDictionary<TState, TEvent> stateDefinitions,
             TState initialStateId)
         {
@@ -213,7 +202,7 @@ namespace Appccelerate.StateMachine.AsyncMachine
             var newStateId = await initializer.EnterInitialState(this.stateLogic, stateContainer).
                 ConfigureAwait(false);
             var newStateDefinition = stateDefinitions[newStateId];
-            await SwitchStateTo(newStateDefinition, stateContainer, stateMachineInformation)
+            await SwitchStateTo(newStateDefinition, stateContainer)
                 .ConfigureAwait(false);
         }
 

--- a/source/Appccelerate.StateMachine/AsyncMachine/StateMachine.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/StateMachine.cs
@@ -126,7 +126,7 @@ namespace Appccelerate.StateMachine.AsyncMachine
 
             var currentState = stateContainer.CurrentState.ExtractOrThrow();
             var context = this.factory.CreateTransitionContext(currentState, new Missable<TEvent>(eventId), eventArgument, this);
-            var result = await this.stateLogic.Fire(currentState, context, stateContainer)
+            var result = await this.stateLogic.Fire(currentState, context, stateContainer, stateDefinitions)
                 .ConfigureAwait(false);
 
             if (!result.Fired)
@@ -199,7 +199,7 @@ namespace Appccelerate.StateMachine.AsyncMachine
         {
             var initialState = stateDefinitions[initialStateId];
             var initializer = this.factory.CreateStateMachineInitializer(initialState, context);
-            var newStateId = await initializer.EnterInitialState(this.stateLogic, stateContainer).
+            var newStateId = await initializer.EnterInitialState(this.stateLogic, stateContainer, stateDefinitions).
                 ConfigureAwait(false);
             var newStateDefinition = stateDefinitions[newStateId];
             await SwitchStateTo(newStateDefinition, stateContainer)

--- a/source/Appccelerate.StateMachine/AsyncMachine/StateMachineDefinition.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/StateMachineDefinition.cs
@@ -55,8 +55,8 @@ namespace Appccelerate.StateMachine.AsyncMachine
                 stateContainer.SetLastActiveStateFor(stateIdAndLastActiveState.Key, stateIdAndLastActiveState.Value);
             }
 
-            var transitionLogic = new TransitionLogic<TState, TEvent>(stateContainer, stateContainer);
-            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, stateContainer, stateContainer);
+            var transitionLogic = new TransitionLogic<TState, TEvent>(stateContainer);
+            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, stateContainer);
             transitionLogic.SetStateLogic(stateLogic);
 
             var standardFactory = new StandardFactory<TState, TEvent>();
@@ -79,8 +79,8 @@ namespace Appccelerate.StateMachine.AsyncMachine
                 stateContainer.SetLastActiveStateFor(stateIdAndLastActiveState.Key, stateIdAndLastActiveState.Value);
             }
 
-            var transitionLogic = new TransitionLogic<TState, TEvent>(stateContainer, stateContainer);
-            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, stateContainer, stateContainer);
+            var transitionLogic = new TransitionLogic<TState, TEvent>(stateContainer);
+            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, stateContainer);
             transitionLogic.SetStateLogic(stateLogic);
 
             var standardFactory = new StandardFactory<TState, TEvent>();

--- a/source/Appccelerate.StateMachine/AsyncMachine/StateMachineDefinition.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/StateMachineDefinition.cs
@@ -28,12 +28,12 @@ namespace Appccelerate.StateMachine.AsyncMachine
         where TEvent : IComparable
     {
         private readonly IStateDefinitionDictionary<TState, TEvent> stateDefinitions;
-        private readonly IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates;
+        private readonly IReadOnlyDictionary<TState, TState> initiallyLastActiveStates;
         private readonly TState initialState;
 
         public StateMachineDefinition(
             IStateDefinitionDictionary<TState, TEvent> stateDefinitions,
-            IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates,
+            IReadOnlyDictionary<TState, TState> initiallyLastActiveStates,
             TState initialState)
         {
             this.stateDefinitions = stateDefinitions;

--- a/source/Appccelerate.StateMachine/AsyncMachine/StateMachineDefinitionBuilder.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/StateMachineDefinitionBuilder.cs
@@ -29,7 +29,7 @@ namespace Appccelerate.StateMachine.AsyncMachine
     {
         private readonly StandardFactory<TState, TEvent> factory = new StandardFactory<TState, TEvent>();
         private readonly ImplicitAddIfNotAvailableStateDefinitionDictionary<TState, TEvent> stateDefinitionDictionary = new ImplicitAddIfNotAvailableStateDefinitionDictionary<TState, TEvent>();
-        private readonly Dictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates = new Dictionary<TState, IStateDefinition<TState, TEvent>>();
+        private readonly Dictionary<TState, TState> initiallyLastActiveStates = new Dictionary<TState, TState>();
         private TState initialState;
         private bool isInitialStateConfigured;
 

--- a/source/Appccelerate.StateMachine/AsyncMachine/StateMachineInitializer.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/StateMachineInitializer.cs
@@ -45,13 +45,14 @@ namespace Appccelerate.StateMachine.AsyncMachine
 
         public async Task<TState> EnterInitialState(
             IStateLogic<TState, TEvent> stateLogic,
-            ILastActiveStateModifier<TState, TEvent> lastActiveStateModifier)
+            ILastActiveStateModifier<TState> lastActiveStateModifier,
+            IStateDefinitionDictionary<TState, TEvent> stateDefinitions)
         {
             var stack = this.TraverseUpTheStateHierarchy();
             await this.TraverseDownTheStateHierarchyAndEnterStates(stateLogic, stack)
                 .ConfigureAwait(false);
 
-            return await stateLogic.EnterByHistory(this.initialState, this.context, lastActiveStateModifier)
+            return await stateLogic.EnterByHistory(this.initialState, this.context, lastActiveStateModifier, stateDefinitions)
                 .ConfigureAwait(false);
         }
 

--- a/source/Appccelerate.StateMachine/AsyncMachine/States/IStateLogic.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/States/IStateLogic.cs
@@ -32,13 +32,14 @@ namespace Appccelerate.StateMachine.AsyncMachine.States
         /// <param name="stateDefinition">The definition of the state onto which the event should be fired.</param>
         /// <param name="context">The event context.</param>
         /// <param name="lastActiveStateModifier">The last active state modifier.</param>
+        /// <param name="stateDefinitions">The definitions for all states of this state Machine.</param>
         /// <returns>The result of the transition.</returns>
-        Task<ITransitionResult<TState>> Fire(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context, ILastActiveStateModifier<TState, TEvent> lastActiveStateModifier);
+        Task<ITransitionResult<TState>> Fire(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context, ILastActiveStateModifier<TState> lastActiveStateModifier, IStateDefinitionDictionary<TState, TEvent> stateDefinitions);
 
         Task Entry(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context);
 
-        Task Exit(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context, ILastActiveStateModifier<TState, TEvent> lastActiveStateModifier);
+        Task Exit(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context, ILastActiveStateModifier<TState> lastActiveStateModifier);
 
-        Task<TState> EnterByHistory(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context, ILastActiveStateModifier<TState, TEvent> lastActiveStateModifier);
+        Task<TState> EnterByHistory(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context, ILastActiveStateModifier<TState> lastActiveStateModifier, IStateDefinitionDictionary<TState, TEvent> stateDefinitions);
     }
 }

--- a/source/Appccelerate.StateMachine/AsyncMachine/States/StateLogic.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/States/StateLogic.cs
@@ -29,16 +29,13 @@ namespace Appccelerate.StateMachine.AsyncMachine.States
         where TEvent : IComparable
     {
         private readonly IExtensionHost<TState, TEvent> extensionHost;
-        private readonly IStateMachineInformation<TState, TEvent> stateMachineInformation;
         private readonly ITransitionLogic<TState, TEvent> transitionLogic;
 
         public StateLogic(
             ITransitionLogic<TState, TEvent> transitionLogic,
-            IExtensionHost<TState, TEvent> extensionHost,
-            IStateMachineInformation<TState, TEvent> stateMachineInformation)
+            IExtensionHost<TState, TEvent> extensionHost)
         {
             this.extensionHost = extensionHost;
-            this.stateMachineInformation = stateMachineInformation;
             this.transitionLogic = transitionLogic;
         }
 
@@ -88,8 +85,7 @@ namespace Appccelerate.StateMachine.AsyncMachine.States
 
             await this.extensionHost.ForEach(
                 extension =>
-                    extension.EnteringState(
-                        this.stateMachineInformation, stateDefinition, context));
+                    extension.EnteringState(stateDefinition, context));
 
             await this.ExecuteEntryActions(stateDefinition, context).ConfigureAwait(false);
         }
@@ -205,8 +201,7 @@ namespace Appccelerate.StateMachine.AsyncMachine.States
             await this.extensionHost
                 .ForEach(
                     extension =>
-                    extension.HandlingEntryActionException(
-                        this.stateMachineInformation, stateDefinition, context, ref exception))
+                    extension.HandlingEntryActionException(stateDefinition, context, ref exception))
                 .ConfigureAwait(false);
 
             HandleException(exception, context);
@@ -214,8 +209,7 @@ namespace Appccelerate.StateMachine.AsyncMachine.States
             await this.extensionHost
                 .ForEach(
                     extension =>
-                    extension.HandledEntryActionException(
-                        this.stateMachineInformation, stateDefinition, context, exception))
+                    extension.HandledEntryActionException(stateDefinition, context, exception))
                 .ConfigureAwait(false);
         }
 
@@ -256,8 +250,7 @@ namespace Appccelerate.StateMachine.AsyncMachine.States
             await this.extensionHost
                 .ForEach(
                     extension =>
-                    extension.HandlingExitActionException(
-                        this.stateMachineInformation, stateDefinition, context, ref exception))
+                    extension.HandlingExitActionException(stateDefinition, context, ref exception))
                 .ConfigureAwait(false);
 
             HandleException(exception, context);
@@ -265,8 +258,7 @@ namespace Appccelerate.StateMachine.AsyncMachine.States
             await this.extensionHost
                 .ForEach(
                     extension =>
-                    extension.HandledExitActionException(
-                        this.stateMachineInformation, stateDefinition, context, exception))
+                    extension.HandledExitActionException(stateDefinition, context, exception))
                 .ConfigureAwait(false);
         }
 

--- a/source/Appccelerate.StateMachine/AsyncMachine/Transitions/ITransitionLogic.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/Transitions/ITransitionLogic.cs
@@ -30,11 +30,13 @@ namespace Appccelerate.StateMachine.AsyncMachine.Transitions
         /// </summary>
         /// <param name="transitionDefinition">The definition of the transition which should happen.</param>
         /// <param name="context">The event context.</param>
-        /// <returns>The result of the transition.</returns>
         /// <param name="lastActiveStateModifier">The last active state modifier.</param>
+        /// <param name="stateDefinitions">The definitions for all states of this state Machine.</param>
+        /// <returns>The result of the transition.</returns>
         Task<ITransitionResult<TState>> Fire(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> context,
-            ILastActiveStateModifier<TState, TEvent> lastActiveStateModifier);
+            ILastActiveStateModifier<TState> lastActiveStateModifier,
+            IStateDefinitionDictionary<TState, TEvent> stateDefinitions);
     }
 }

--- a/source/Appccelerate.StateMachine/AsyncMachine/Transitions/TransitionLogic.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/Transitions/TransitionLogic.cs
@@ -28,16 +28,12 @@ namespace Appccelerate.StateMachine.AsyncMachine.Transitions
         where TEvent : IComparable
     {
         private readonly IExtensionHost<TState, TEvent> extensionHost;
-        private readonly IStateMachineInformation<TState, TEvent> stateMachineInformation;
 
         private IStateLogic<TState, TEvent> stateLogic;
 
-        public TransitionLogic(
-            IExtensionHost<TState, TEvent> extensionHost,
-            IStateMachineInformation<TState, TEvent> stateMachineInformation)
+        public TransitionLogic(IExtensionHost<TState, TEvent> extensionHost)
         {
             this.extensionHost = extensionHost;
-            this.stateMachineInformation = stateMachineInformation;
         }
 
         public void SetStateLogic(IStateLogic<TState, TEvent> stateLogicToSet)
@@ -57,7 +53,6 @@ namespace Appccelerate.StateMachine.AsyncMachine.Transitions
             {
                 await this.extensionHost
                     .ForEach(extension => extension.SkippedTransition(
-                        this.stateMachineInformation,
                         transitionDefinition,
                         context))
                     .ConfigureAwait(false);
@@ -69,7 +64,6 @@ namespace Appccelerate.StateMachine.AsyncMachine.Transitions
 
             await this.extensionHost
                 .ForEach(extension => extension.ExecutingTransition(
-                    this.stateMachineInformation,
                     transitionDefinition,
                     context))
                 .ConfigureAwait(false);
@@ -93,7 +87,6 @@ namespace Appccelerate.StateMachine.AsyncMachine.Transitions
 
             await this.extensionHost
                 .ForEach(extension => extension.ExecutedTransition(
-                    this.stateMachineInformation,
                     transitionDefinition,
                     context))
                 .ConfigureAwait(false);
@@ -213,13 +206,13 @@ namespace Appccelerate.StateMachine.AsyncMachine.Transitions
             catch (Exception exception)
             {
                 await this.extensionHost
-                    .ForEach(extension => extension.HandlingGuardException(this.stateMachineInformation, transitionDefinition, context, ref exception))
+                    .ForEach(extension => extension.HandlingGuardException(transitionDefinition, context, ref exception))
                     .ConfigureAwait(false);
 
                 HandleException(exception, context);
 
                 await this.extensionHost
-                    .ForEach(extension => extension.HandledGuardException(this.stateMachineInformation, transitionDefinition, context, exception))
+                    .ForEach(extension => extension.HandledGuardException(transitionDefinition, context, exception))
                     .ConfigureAwait(false);
 
                 return false;
@@ -237,13 +230,13 @@ namespace Appccelerate.StateMachine.AsyncMachine.Transitions
                 catch (Exception exception)
                 {
                     await this.extensionHost
-                        .ForEach(extension => extension.HandlingTransitionException(this.stateMachineInformation, transitionDefinition, context, ref exception))
+                        .ForEach(extension => extension.HandlingTransitionException(transitionDefinition, context, ref exception))
                         .ConfigureAwait(false);
 
                     HandleException(exception, context);
 
                     await this.extensionHost
-                        .ForEach(extension => extension.HandledTransitionException(this.stateMachineInformation, transitionDefinition, context, exception))
+                        .ForEach(extension => extension.HandledTransitionException(transitionDefinition, context, exception))
                         .ConfigureAwait(false);
                 }
             }

--- a/source/Appccelerate.StateMachine/AsyncMachine/Transitions/TransitionLogic.cs
+++ b/source/Appccelerate.StateMachine/AsyncMachine/Transitions/TransitionLogic.cs
@@ -44,7 +44,8 @@ namespace Appccelerate.StateMachine.AsyncMachine.Transitions
         public async Task<ITransitionResult<TState>> Fire(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> context,
-            ILastActiveStateModifier<TState, TEvent> lastActiveStateModifier)
+            ILastActiveStateModifier<TState> lastActiveStateModifier,
+            IStateDefinitionDictionary<TState, TEvent> stateDefinitions)
         {
             Guard.AgainstNullArgument("context", context);
 
@@ -77,7 +78,7 @@ namespace Appccelerate.StateMachine.AsyncMachine.Transitions
                 await this.Fire(transitionDefinition, transitionDefinition.Source, transitionDefinition.Target, context, lastActiveStateModifier)
                     .ConfigureAwait(false);
 
-                newState = await this.stateLogic.EnterByHistory(transitionDefinition.Target, context, lastActiveStateModifier)
+                newState = await this.stateLogic.EnterByHistory(transitionDefinition.Target, context, lastActiveStateModifier, stateDefinitions)
                     .ConfigureAwait(false);
             }
             else
@@ -141,7 +142,7 @@ namespace Appccelerate.StateMachine.AsyncMachine.Transitions
             IStateDefinition<TState, TEvent> source,
             IStateDefinition<TState, TEvent> target,
             ITransitionContext<TState, TEvent> context,
-            ILastActiveStateModifier<TState, TEvent> lastActiveStateModifier)
+            ILastActiveStateModifier<TState> lastActiveStateModifier)
         {
             if (source == transitionDefinition.Target)
             {
@@ -245,7 +246,7 @@ namespace Appccelerate.StateMachine.AsyncMachine.Transitions
         private async Task UnwindSubStates(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> context,
-            ILastActiveStateModifier<TState, TEvent> lastActiveStateModifier)
+            ILastActiveStateModifier<TState> lastActiveStateModifier)
         {
             var o = context.StateDefinition;
             while (o != transitionDefinition.Source)

--- a/source/Appccelerate.StateMachine/AsyncPassiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/AsyncPassiveStateMachine.cs
@@ -290,7 +290,9 @@ namespace Appccelerate.StateMachine
                 this.stateContainer.Extensions.ForEach(
                     extension => extension.Loaded(
                         loadedCurrentState,
-                        historyStates));
+                        historyStates,
+                        events,
+                        priorityEvents));
             }
         }
 

--- a/source/Appccelerate.StateMachine/AsyncPassiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/AsyncPassiveStateMachine.cs
@@ -121,7 +121,7 @@ namespace Appccelerate.StateMachine
             this.events.Enqueue(new EventInformation<TEvent>(eventId, eventArgument));
 
             await this.stateContainer
-                .ForEach(extension => extension.EventQueued(this.stateContainer, eventId, eventArgument))
+                .ForEach(extension => extension.EventQueued(eventId, eventArgument))
                 .ConfigureAwait(false);
 
             await this.Execute().ConfigureAwait(false);
@@ -148,7 +148,7 @@ namespace Appccelerate.StateMachine
             this.priorityEvents.Push(new EventInformation<TEvent>(eventId, eventArgument));
 
             await this.stateContainer
-                .ForEach(extension => extension.EventQueuedWithPriority(this.stateContainer, eventId, eventArgument))
+                .ForEach(extension => extension.EventQueuedWithPriority(eventId, eventArgument))
                 .ConfigureAwait(false);
 
             await this.Execute().ConfigureAwait(false);
@@ -164,7 +164,7 @@ namespace Appccelerate.StateMachine
         {
             this.IsRunning = true;
 
-            await this.stateContainer.ForEach(extension => extension.StartedStateMachine(this.stateContainer))
+            await this.stateContainer.ForEach(extension => extension.StartedStateMachine())
                 .ConfigureAwait(false);
 
             await this.Execute().ConfigureAwait(false);
@@ -192,7 +192,7 @@ namespace Appccelerate.StateMachine
         {
             this.IsRunning = false;
 
-            await this.stateContainer.ForEach(extension => extension.StoppedStateMachine(this.stateContainer))
+            await this.stateContainer.ForEach(extension => extension.StoppedStateMachine())
                 .ConfigureAwait(false);
         }
 
@@ -202,7 +202,8 @@ namespace Appccelerate.StateMachine
         /// <param name="extension">The extension.</param>
         public void AddExtension(IExtension<TState, TEvent> extension)
         {
-            this.stateContainer.Extensions.Add(extension);
+            var extensionCompose = new InternalExtension<TState, TEvent>(extension, this.stateContainer);
+            this.stateContainer.Extensions.Add(extensionCompose);
         }
 
         /// <summary>
@@ -278,7 +279,6 @@ namespace Appccelerate.StateMachine
             {
                 this.stateContainer.Extensions.ForEach(
                     extension => extension.Loaded(
-                        this.stateContainer,
                         loadedCurrentState,
                         historyStates));
             }
@@ -321,7 +321,6 @@ namespace Appccelerate.StateMachine
                         eventInformation.EventId,
                         eventInformation.EventArgument,
                         this.stateContainer,
-                        this.stateContainer,
                         this.stateDefinitions)
                     .ConfigureAwait(false);
             }
@@ -331,7 +330,6 @@ namespace Appccelerate.StateMachine
                 await this.stateMachine.Fire(
                         eventInformation.EventId,
                         eventInformation.EventArgument,
-                        this.stateContainer,
                         this.stateContainer,
                         this.stateDefinitions)
                     .ConfigureAwait(false);
@@ -345,7 +343,7 @@ namespace Appccelerate.StateMachine
                 return;
             }
 
-            await this.stateMachine.EnterInitialState(this.stateContainer, this.stateContainer, this.stateDefinitions, this.initialState)
+            await this.stateMachine.EnterInitialState(this.stateContainer, this.stateDefinitions, this.initialState)
                 .ConfigureAwait(false);
         }
     }

--- a/source/Appccelerate.StateMachine/AsyncPassiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/AsyncPassiveStateMachine.cs
@@ -254,7 +254,7 @@ namespace Appccelerate.StateMachine
 
             void SetCurrentState()
             {
-                this.stateContainer.CurrentState = loadedCurrentState.Map(x => this.stateDefinitions[x]);
+                this.stateContainer.CurrentStateId = loadedCurrentState;
             }
 
             void LoadHistoryStates()
@@ -289,7 +289,7 @@ namespace Appccelerate.StateMachine
 
         private void CheckThatNotAlreadyInitialized()
         {
-            if (this.stateContainer.CurrentState.IsInitialized)
+            if (this.stateContainer.CurrentStateId.IsInitialized)
             {
                 throw new InvalidOperationException(ExceptionMessages.StateMachineIsAlreadyInitialized);
             }
@@ -341,7 +341,7 @@ namespace Appccelerate.StateMachine
 
         private async Task InitializeStateMachineIfInitializationIsPending()
         {
-            if (this.stateContainer.CurrentState.IsInitialized)
+            if (this.stateContainer.CurrentStateId.IsInitialized)
             {
                 return;
             }

--- a/source/Appccelerate.StateMachine/AsyncPassiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/AsyncPassiveStateMachine.cs
@@ -227,10 +227,8 @@ namespace Appccelerate.StateMachine
                 .ConfigureAwait(false);
 
             var historyStates = this.stateContainer
-                .LastActiveStates
-                .ToDictionary(
-                    pair => pair.Key,
-                    pair => pair.Value.Id);
+                .LastActiveStates;
+
             await stateMachineSaver.SaveHistoryStates(historyStates)
                 .ConfigureAwait(false);
         }
@@ -264,9 +262,14 @@ namespace Appccelerate.StateMachine
                 foreach (var historyState in historyStates)
                 {
                     var superState = this.stateDefinitions[historyState.Key];
-                    var lastActiveState = this.stateDefinitions[historyState.Value];
+                    var lastActiveState = historyState.Value;
 
-                    if (!superState.SubStates.Contains(lastActiveState))
+                    var lastActiveStateIsNotASubStateOfSuperState = superState
+                                                                        .SubStates
+                                                                        .Select(x => x.Id)
+                                                                        .Contains(lastActiveState)
+                                                                    == false;
+                    if (lastActiveStateIsNotASubStateOfSuperState)
                     {
                         throw new InvalidOperationException(ExceptionMessages.CannotSetALastActiveStateThatIsNotASubState);
                     }

--- a/source/Appccelerate.StateMachine/EventInformation.cs
+++ b/source/Appccelerate.StateMachine/EventInformation.cs
@@ -33,8 +33,8 @@ namespace Appccelerate.StateMachine
             this.EventArgument = eventArgument;
         }
 
-        public TEvent EventId { get; private set; }
+        public TEvent EventId { get; }
 
-        public object EventArgument { get; private set; }
+        public object EventArgument { get; }
     }
 }

--- a/source/Appccelerate.StateMachine/Extensions/ExtensionBase.cs
+++ b/source/Appccelerate.StateMachine/Extensions/ExtensionBase.cs
@@ -255,7 +255,8 @@ namespace Appccelerate.StateMachine.Extensions
         public virtual void Loaded(
             IStateMachineInformation<TState, TEvent> stateMachineInformation,
             IInitializable<TState> loadedCurrentState,
-            IReadOnlyDictionary<TState, TState> loadedHistoryStates)
+            IReadOnlyDictionary<TState, TState> loadedHistoryStates,
+            IReadOnlyCollection<EventInformation<TEvent>> events)
         {
         }
     }

--- a/source/Appccelerate.StateMachine/Extensions/InternalExtension.cs
+++ b/source/Appccelerate.StateMachine/Extensions/InternalExtension.cs
@@ -172,9 +172,10 @@ namespace Appccelerate.StateMachine.Extensions
 
         public void Loaded(
             IInitializable<TState> loadedCurrentState,
-            IReadOnlyDictionary<TState, TState> loadedHistoryStates)
+            IReadOnlyDictionary<TState, TState> loadedHistoryStates,
+            IReadOnlyCollection<EventInformation<TEvent>> events)
         {
-            this.apiExtension.Loaded(this.stateMachineInformation, loadedCurrentState, loadedHistoryStates);
+            this.apiExtension.Loaded(this.stateMachineInformation, loadedCurrentState, loadedHistoryStates, events);
         }
 
         public void EnteringState(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context)

--- a/source/Appccelerate.StateMachine/Extensions/InternalExtension.cs
+++ b/source/Appccelerate.StateMachine/Extensions/InternalExtension.cs
@@ -176,5 +176,10 @@ namespace Appccelerate.StateMachine.Extensions
         {
             this.apiExtension.Loaded(this.stateMachineInformation, loadedCurrentState, loadedHistoryStates);
         }
+
+        public void EnteringState(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context)
+        {
+            this.apiExtension.EnteringState(this.stateMachineInformation, stateDefinition, context);
+        }
     }
 }

--- a/source/Appccelerate.StateMachine/Extensions/InternalExtension.cs
+++ b/source/Appccelerate.StateMachine/Extensions/InternalExtension.cs
@@ -1,0 +1,180 @@
+//-------------------------------------------------------------------------------
+// <copyright file="InternalExtension.cs" company="Appccelerate">
+//   Copyright (c) 2008-2019 Appccelerate
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+namespace Appccelerate.StateMachine.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    using Infrastructure;
+    using Machine;
+    using Machine.States;
+    using Machine.Transitions;
+
+    public class InternalExtension<TState, TEvent> : IExtensionInternal<TState, TEvent>
+        where TState : IComparable
+        where TEvent : IComparable
+    {
+        private readonly IExtension<TState, TEvent> apiExtension;
+        private readonly IStateMachineInformation<TState, TEvent> stateMachineInformation;
+
+        public InternalExtension(
+            IExtension<TState, TEvent> apiExtension,
+            IStateMachineInformation<TState, TEvent> stateMachineInformation)
+        {
+            this.apiExtension = apiExtension;
+            this.stateMachineInformation = stateMachineInformation;
+        }
+
+        public void StartedStateMachine()
+        {
+            this.apiExtension.StartedStateMachine(this.stateMachineInformation);
+        }
+
+        public void StoppedStateMachine()
+        {
+            this.apiExtension.StoppedStateMachine(this.stateMachineInformation);
+        }
+
+        public void EventQueued(TEvent eventId, object eventArgument)
+        {
+            this.apiExtension.EventQueued(this.stateMachineInformation, eventId, eventArgument);
+        }
+
+        public void EventQueuedWithPriority(TEvent eventId, object eventArgument)
+        {
+            this.apiExtension.EventQueuedWithPriority(this.stateMachineInformation, eventId, eventArgument);
+        }
+
+        public void SwitchedState(IStateDefinition<TState, TEvent> oldState, IStateDefinition<TState, TEvent> newState)
+        {
+            this.apiExtension.SwitchedState(this.stateMachineInformation, oldState, newState);
+        }
+
+        public void EnteringInitialState(TState state)
+        {
+            this.apiExtension.EnteringInitialState(this.stateMachineInformation, state);
+        }
+
+        public void EnteredInitialState(TState state, ITransitionContext<TState, TEvent> context)
+        {
+            this.apiExtension.EnteredInitialState(this.stateMachineInformation, state, context);
+        }
+
+        public void FiringEvent(ref TEvent eventId, ref object eventArgument)
+        {
+            this.apiExtension.FiringEvent(this.stateMachineInformation, ref eventId, ref eventArgument);
+        }
+
+        public void FiredEvent(ITransitionContext<TState, TEvent> context)
+        {
+            this.apiExtension.FiredEvent(this.stateMachineInformation, context);
+        }
+
+        public void HandlingEntryActionException(
+            IStateDefinition<TState, TEvent> stateDefinition,
+            ITransitionContext<TState, TEvent> context,
+            ref Exception exception)
+        {
+            this.apiExtension.HandlingEntryActionException(this.stateMachineInformation, stateDefinition, context, ref exception);
+        }
+
+        public void HandledEntryActionException(
+            IStateDefinition<TState, TEvent> stateDefinition,
+            ITransitionContext<TState, TEvent> context,
+            Exception exception)
+        {
+            this.apiExtension.HandledEntryActionException(this.stateMachineInformation, stateDefinition, context, exception);
+        }
+
+        public void HandlingExitActionException(
+            IStateDefinition<TState, TEvent> stateDefinition,
+            ITransitionContext<TState, TEvent> context,
+            ref Exception exception)
+        {
+            this.apiExtension.HandlingExitActionException(this.stateMachineInformation, stateDefinition, context, ref exception);
+        }
+
+        public void HandledExitActionException(
+            IStateDefinition<TState, TEvent> stateDefinition,
+            ITransitionContext<TState, TEvent> context,
+            Exception exception)
+        {
+            this.apiExtension.HandledExitActionException(this.stateMachineInformation, stateDefinition, context, exception);
+        }
+
+        public void HandlingGuardException(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext,
+            ref Exception exception)
+        {
+            this.apiExtension.HandlingGuardException(this.stateMachineInformation, transitionDefinition, transitionContext, ref exception);
+        }
+
+        public void HandledGuardException(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext,
+            Exception exception)
+        {
+            this.apiExtension.HandledGuardException(this.stateMachineInformation, transitionDefinition, transitionContext, exception);
+        }
+
+        public void HandlingTransitionException(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> context,
+            ref Exception exception)
+        {
+            this.apiExtension.HandlingTransitionException(this.stateMachineInformation, transitionDefinition, context, ref exception);
+        }
+
+        public void HandledTransitionException(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext,
+            Exception exception)
+        {
+            this.apiExtension.HandledTransitionException(this.stateMachineInformation, transitionDefinition, transitionContext, exception);
+        }
+
+        public void SkippedTransition(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> context)
+        {
+            this.apiExtension.SkippedTransition(this.stateMachineInformation, transitionDefinition, context);
+        }
+
+        public void ExecutingTransition(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext)
+        {
+            this.apiExtension.ExecutingTransition(this.stateMachineInformation, transitionDefinition, transitionContext);
+        }
+
+        public void ExecutedTransition(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext)
+        {
+            this.apiExtension.ExecutedTransition(this.stateMachineInformation, transitionDefinition, transitionContext);
+        }
+
+        public void Loaded(
+            IInitializable<TState> loadedCurrentState,
+            IReadOnlyDictionary<TState, TState> loadedHistoryStates)
+        {
+            this.apiExtension.Loaded(this.stateMachineInformation, loadedCurrentState, loadedHistoryStates);
+        }
+    }
+}

--- a/source/Appccelerate.StateMachine/Extensions/InternalExtensionBase.cs
+++ b/source/Appccelerate.StateMachine/Extensions/InternalExtensionBase.cs
@@ -1,0 +1,148 @@
+//-------------------------------------------------------------------------------
+// <copyright file="InternalExtensionBase.cs" company="Appccelerate">
+//   Copyright (c) 2008-2019 Appccelerate
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+namespace Appccelerate.StateMachine.Extensions
+{
+    using System;
+    using System.Collections.Generic;
+    using Infrastructure;
+    using Machine;
+    using Machine.States;
+    using Machine.Transitions;
+
+    public class InternalExtensionBase<TState, TEvent> : IExtensionInternal<TState, TEvent>
+        where TState : IComparable
+        where TEvent : IComparable
+    {
+        public virtual void StartedStateMachine()
+        {
+        }
+
+        public virtual void StoppedStateMachine()
+        {
+        }
+
+        public virtual void EventQueued(TEvent eventId, object eventArgument)
+        {
+        }
+
+        public virtual void EventQueuedWithPriority(TEvent eventId, object eventArgument)
+        {
+        }
+
+        public virtual void SwitchedState(IStateDefinition<TState, TEvent> oldState, IStateDefinition<TState, TEvent> newState)
+        {
+        }
+
+        public virtual void EnteringInitialState(TState state)
+        {
+        }
+
+        public virtual void EnteredInitialState(TState state, ITransitionContext<TState, TEvent> context)
+        {
+        }
+
+        public virtual void FiringEvent(ref TEvent eventId, ref object eventArgument)
+        {
+        }
+
+        public virtual void FiredEvent(ITransitionContext<TState, TEvent> context)
+        {
+        }
+
+        public virtual void HandlingEntryActionException(
+            IStateDefinition<TState, TEvent> stateDefinition,
+            ITransitionContext<TState, TEvent> context,
+            ref Exception exception)
+        {
+        }
+
+        public virtual void HandledEntryActionException(
+            IStateDefinition<TState, TEvent> stateDefinition,
+            ITransitionContext<TState, TEvent> context,
+            Exception exception)
+        {
+        }
+
+        public virtual void HandlingExitActionException(
+            IStateDefinition<TState, TEvent> stateDefinition,
+            ITransitionContext<TState, TEvent> context,
+            ref Exception exception)
+        {
+        }
+
+        public virtual void HandledExitActionException(
+            IStateDefinition<TState, TEvent> stateDefinition,
+            ITransitionContext<TState, TEvent> context,
+            Exception exception)
+        {
+        }
+
+        public virtual void HandlingGuardException(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext,
+            ref Exception exception)
+        {
+        }
+
+        public virtual void HandledGuardException(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext,
+            Exception exception)
+        {
+        }
+
+        public virtual void HandlingTransitionException(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> context,
+            ref Exception exception)
+        {
+        }
+
+        public virtual void HandledTransitionException(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext,
+            Exception exception)
+        {
+        }
+
+        public virtual void SkippedTransition(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> context)
+        {
+        }
+
+        public virtual void ExecutingTransition(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext)
+        {
+        }
+
+        public virtual void ExecutedTransition(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext)
+        {
+        }
+
+        public virtual void Loaded(
+            IInitializable<TState> loadedCurrentState,
+            IReadOnlyDictionary<TState, TState> loadedHistoryStates)
+        {
+        }
+    }
+}

--- a/source/Appccelerate.StateMachine/Extensions/InternalExtensionBase.cs
+++ b/source/Appccelerate.StateMachine/Extensions/InternalExtensionBase.cs
@@ -141,7 +141,8 @@ namespace Appccelerate.StateMachine.Extensions
 
         public virtual void Loaded(
             IInitializable<TState> loadedCurrentState,
-            IReadOnlyDictionary<TState, TState> loadedHistoryStates)
+            IReadOnlyDictionary<TState, TState> loadedHistoryStates,
+            IReadOnlyCollection<EventInformation<TEvent>> events)
         {
         }
 

--- a/source/Appccelerate.StateMachine/IAsyncStateMachine.cs
+++ b/source/Appccelerate.StateMachine/IAsyncStateMachine.cs
@@ -125,7 +125,7 @@ namespace Appccelerate.StateMachine
         /// </summary>
         /// <param name="stateMachineSaver">Data to be persisted is passed to the saver.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task Save(IAsyncStateMachineSaver<TState> stateMachineSaver);
+        Task Save(IAsyncStateMachineSaver<TState, TEvent> stateMachineSaver);
 
         /// <summary>
         /// Loads the current state and history states from a persisted state (<see cref="Save(Appccelerate.StateMachine.Persistence.IAsyncStateMachineSaver{TState})"/>).
@@ -133,6 +133,6 @@ namespace Appccelerate.StateMachine
         /// </summary>
         /// <param name="stateMachineLoader">Loader providing persisted data.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task Load(IAsyncStateMachineLoader<TState> stateMachineLoader);
+        Task Load(IAsyncStateMachineLoader<TState, TEvent> stateMachineLoader);
     }
 }

--- a/source/Appccelerate.StateMachine/IAsyncStateMachine.cs
+++ b/source/Appccelerate.StateMachine/IAsyncStateMachine.cs
@@ -121,14 +121,14 @@ namespace Appccelerate.StateMachine
         void Report(IStateMachineReport<TState, TEvent> reportGenerator);
 
         /// <summary>
-        /// Saves the current state and history states to a persisted state. Can be restored using <see cref="Load(Appccelerate.StateMachine.Persistence.IAsyncStateMachineLoader{TState})"/>.
+        /// Saves the current state and history states to a persisted state. Can be restored using <see cref="Load(IAsyncStateMachineLoader{TState,TEvent})"/>.
         /// </summary>
         /// <param name="stateMachineSaver">Data to be persisted is passed to the saver.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task Save(IAsyncStateMachineSaver<TState, TEvent> stateMachineSaver);
 
         /// <summary>
-        /// Loads the current state and history states from a persisted state (<see cref="Save(Appccelerate.StateMachine.Persistence.IAsyncStateMachineSaver{TState})"/>).
+        /// Loads the current state and history states from a persisted state (<see cref="Save(IAsyncStateMachineSaver{TState, TEvent})"/>).
         /// The loader should return exactly the data that was passed to the saver.
         /// </summary>
         /// <param name="stateMachineLoader">Loader providing persisted data.</param>

--- a/source/Appccelerate.StateMachine/IStateMachine.cs
+++ b/source/Appccelerate.StateMachine/IStateMachine.cs
@@ -118,13 +118,13 @@ namespace Appccelerate.StateMachine
         /// Saves the current state and history states to a persisted state. Can be restored using <see cref="Load"/>.
         /// </summary>
         /// <param name="stateMachineSaver">Data to be persisted is passed to the saver.</param>
-        void Save(IStateMachineSaver<TState> stateMachineSaver);
+        void Save(IStateMachineSaver<TState, TEvent> stateMachineSaver);
 
         /// <summary>
         /// Loads the current state and history states from a persisted state (<see cref="Save"/>).
         /// The loader should return exactly the data that was passed to the saver.
         /// </summary>
         /// <param name="stateMachineLoader">Loader providing persisted data.</param>
-        void Load(IStateMachineLoader<TState> stateMachineLoader);
+        void Load(IStateMachineLoader<TState, TEvent> stateMachineLoader);
     }
 }

--- a/source/Appccelerate.StateMachine/Infrastructure/IInitializable.cs
+++ b/source/Appccelerate.StateMachine/Infrastructure/IInitializable.cs
@@ -22,8 +22,6 @@ namespace Appccelerate.StateMachine.Infrastructure
 
     public interface IInitializable<out T>
     {
-        T Value { get; }
-
         bool IsInitialized { get; }
 
         Initializable<TResult> Map<TResult>(Func<T, TResult> func);

--- a/source/Appccelerate.StateMachine/Infrastructure/Initializable.cs
+++ b/source/Appccelerate.StateMachine/Infrastructure/Initializable.cs
@@ -29,6 +29,17 @@ namespace Appccelerate.StateMachine.Infrastructure
     {
         private T value;
 
+        /// <summary>
+        /// Gets a value indicating whether this instance is initialized (has a set value).
+        /// </summary>
+        /// <value><c>true</c> if this instance is initialized; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsInitialized { get; private set; }
+
+        private Initializable()
+        {
+        }
+
         public static Initializable<T> UnInitialized()
         {
             return new Initializable<T>();
@@ -65,49 +76,11 @@ namespace Appccelerate.StateMachine.Infrastructure
             return this.value;
         }
 
-        /// <summary>
-        /// Gets or sets the value.
-        /// </summary>
-        /// <value>The value.</value>
-        public T Value
-        {
-            get
-            {
-                this.CheckInitialized();
-
-                return this.value;
-            }
-
-            set
-            {
-                this.CheckNotAlreadyInitialized();
-
-                this.IsInitialized = true;
-
-                this.value = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether this instance is initialized (has a set value).
-        /// </summary>
-        /// <value><c>true</c> if this instance is initialized; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsInitialized { get; private set; }
-
         private void CheckInitialized()
         {
             if (!this.IsInitialized)
             {
                 throw new InvalidOperationException(ExceptionMessages.ValueNotInitialized);
-            }
-        }
-
-        private void CheckNotAlreadyInitialized()
-        {
-            if (this.IsInitialized)
-            {
-                throw new InvalidOperationException(ExceptionMessages.ValueAlreadyInitialized);
             }
         }
     }

--- a/source/Appccelerate.StateMachine/Infrastructure/Optional.cs
+++ b/source/Appccelerate.StateMachine/Infrastructure/Optional.cs
@@ -16,7 +16,7 @@
 // </copyright>
 //-------------------------------------------------------------------------------
 
-namespace Appccelerate.StateMachine.Machine
+namespace Appccelerate.StateMachine.Infrastructure
 {
     public class Optional<T>
     {

--- a/source/Appccelerate.StateMachine/Machine/ExceptionMessages.cs
+++ b/source/Appccelerate.StateMachine/Machine/ExceptionMessages.cs
@@ -35,11 +35,6 @@ namespace Appccelerate.StateMachine.Machine
         public const string ValueNotInitialized = "Value is not initialized";
 
         /// <summary>
-        /// Value is already initialized.
-        /// </summary>
-        public const string ValueAlreadyInitialized = "Value is already initialized";
-
-        /// <summary>
         /// State machine is already initialized.
         /// </summary>
         public const string StateMachineIsAlreadyInitialized = "state machine is already initialized";

--- a/source/Appccelerate.StateMachine/Machine/HierarchyBuilder.cs
+++ b/source/Appccelerate.StateMachine/Machine/HierarchyBuilder.cs
@@ -33,12 +33,12 @@ namespace Appccelerate.StateMachine.Machine
         private readonly StateDefinition<TState, TEvent> superState;
 
         private readonly IImplicitAddIfNotAvailableStateDefinitionDictionary<TState, TEvent> stateDefinitions;
-        private readonly IDictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates;
+        private readonly IDictionary<TState, TState> initiallyLastActiveStates;
 
         public HierarchyBuilder(
             TState superStateId,
             IImplicitAddIfNotAvailableStateDefinitionDictionary<TState, TEvent> stateDefinitions,
-            IDictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates)
+            IDictionary<TState, TState> initiallyLastActiveStates)
         {
             Guard.AgainstNullArgument("states", stateDefinitions);
 
@@ -59,7 +59,7 @@ namespace Appccelerate.StateMachine.Machine
             this.WithSubState(stateId);
 
             this.superState.InitialStateModifiable = this.stateDefinitions[stateId];
-            this.initiallyLastActiveStates.Add(this.superState.Id, this.stateDefinitions[stateId]);
+            this.initiallyLastActiveStates.Add(this.superState.Id, stateId);
 
             return this;
         }

--- a/source/Appccelerate.StateMachine/Machine/IExtension.cs
+++ b/source/Appccelerate.StateMachine/Machine/IExtension.cs
@@ -252,6 +252,7 @@ namespace Appccelerate.StateMachine.Machine
         void Loaded(
             IStateMachineInformation<TState, TEvent> stateMachineInformation,
             IInitializable<TState> loadedCurrentState,
-            IReadOnlyDictionary<TState, TState> loadedHistoryStates);
+            IReadOnlyDictionary<TState, TState> loadedHistoryStates,
+            IReadOnlyCollection<EventInformation<TEvent>> events);
     }
 }

--- a/source/Appccelerate.StateMachine/Machine/IExtensionHost.cs
+++ b/source/Appccelerate.StateMachine/Machine/IExtensionHost.cs
@@ -33,6 +33,6 @@ namespace Appccelerate.StateMachine.Machine
         /// Executes the specified action for all extensions.
         /// </summary>
         /// <param name="action">The action to execute.</param>
-        void ForEach(Action<IExtension<TState, TEvent>> action);
+        void ForEach(Action<IExtensionInternal<TState, TEvent>> action);
     }
 }

--- a/source/Appccelerate.StateMachine/Machine/IExtensionInternal.cs
+++ b/source/Appccelerate.StateMachine/Machine/IExtensionInternal.cs
@@ -1,0 +1,107 @@
+//-------------------------------------------------------------------------------
+// <copyright file="IExtensionInternal.cs" company="Appccelerate">
+//   Copyright (c) 2008-2019 Appccelerate
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+namespace Appccelerate.StateMachine.Machine
+{
+    using System;
+    using System.Collections.Generic;
+    using Infrastructure;
+    using States;
+    using Transitions;
+
+    public interface IExtensionInternal<TState, TEvent>
+        where TState : IComparable
+        where TEvent : IComparable
+    {
+        void StartedStateMachine();
+
+        void StoppedStateMachine();
+
+        void EventQueued(TEvent eventId, object eventArgument);
+
+        void EventQueuedWithPriority(TEvent eventId, object eventArgument);
+
+        void SwitchedState(IStateDefinition<TState, TEvent> oldState, IStateDefinition<TState, TEvent> newState);
+
+        void EnteringInitialState(TState state);
+
+        void EnteredInitialState(TState state, ITransitionContext<TState, TEvent> context);
+
+        void FiringEvent(
+            ref TEvent eventId,
+            ref object eventArgument);
+
+        void FiredEvent(ITransitionContext<TState, TEvent> context);
+
+        void HandlingEntryActionException(
+            IStateDefinition<TState, TEvent> stateDefinition,
+            ITransitionContext<TState, TEvent> context,
+            ref Exception exception);
+
+        void HandledEntryActionException(
+            IStateDefinition<TState, TEvent> stateDefinition,
+            ITransitionContext<TState, TEvent> context,
+            Exception exception);
+
+        void HandlingExitActionException(
+            IStateDefinition<TState, TEvent> stateDefinition,
+            ITransitionContext<TState, TEvent> context,
+            ref Exception exception);
+
+        void HandledExitActionException(
+            IStateDefinition<TState, TEvent> stateDefinition,
+            ITransitionContext<TState, TEvent> context,
+            Exception exception);
+
+        void HandlingGuardException(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext,
+            ref Exception exception);
+
+        void HandledGuardException(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext,
+            Exception exception);
+
+        void HandlingTransitionException(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> context,
+            ref Exception exception);
+
+        void HandledTransitionException(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> transitionContext,
+            Exception exception);
+
+        void SkippedTransition(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> context);
+
+        void ExecutingTransition(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> context);
+
+        void ExecutedTransition(
+            ITransitionDefinition<TState, TEvent> transitionDefinition,
+            ITransitionContext<TState, TEvent> context);
+
+        void Loaded(
+            IInitializable<TState> loadedCurrentState,
+            IReadOnlyDictionary<TState, TState> loadedHistoryStates);
+    }
+}

--- a/source/Appccelerate.StateMachine/Machine/IExtensionInternal.cs
+++ b/source/Appccelerate.StateMachine/Machine/IExtensionInternal.cs
@@ -102,7 +102,8 @@ namespace Appccelerate.StateMachine.Machine
 
         void Loaded(
             IInitializable<TState> loadedCurrentState,
-            IReadOnlyDictionary<TState, TState> loadedHistoryStates);
+            IReadOnlyDictionary<TState, TState> loadedHistoryStates,
+            IReadOnlyCollection<EventInformation<TEvent>> events);
 
         void EnteringState(
             IStateDefinition<TState, TEvent> stateDefinition,

--- a/source/Appccelerate.StateMachine/Machine/ILastActiveStateModifier.cs
+++ b/source/Appccelerate.StateMachine/Machine/ILastActiveStateModifier.cs
@@ -19,6 +19,7 @@
 namespace Appccelerate.StateMachine.Machine
 {
     using System;
+    using Infrastructure;
 
     public interface ILastActiveStateModifier<TState>
         where TState : IComparable

--- a/source/Appccelerate.StateMachine/Machine/Optional.cs
+++ b/source/Appccelerate.StateMachine/Machine/Optional.cs
@@ -1,5 +1,5 @@
 ﻿//-------------------------------------------------------------------------------
-// <copyright file="ILastActiveStateModifier.cs" company="Appccelerate">
+// <copyright file="Optional.cs" company="Appccelerate">
 //   Copyright (c) 2008-2019 Appccelerate
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,13 +18,28 @@
 
 namespace Appccelerate.StateMachine.Machine
 {
-    using System;
-
-    public interface ILastActiveStateModifier<TState>
-        where TState : IComparable
+    public class Optional<T>
     {
-        Optional<TState> GetLastActiveStateFor(TState state);
+        private Optional()
+        {
+        }
 
-        void SetLastActiveStateFor(TState state, TState newLastActiveState);
+        public T Value { get; private set; }
+
+        public bool HasValue { get; private set; }
+
+        public static Optional<T> Just(T value)
+        {
+            return new Optional<T>
+            {
+                HasValue = true,
+                Value = value
+            };
+        }
+
+        public static Optional<T> Nothing()
+        {
+            return new Optional<T>();
+        }
     }
 }

--- a/source/Appccelerate.StateMachine/Machine/StateContainer.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateContainer.cs
@@ -50,6 +50,8 @@ namespace Appccelerate.StateMachine.Machine
 
         public IReadOnlyDictionary<TState, TState> LastActiveStates => this.lastActiveStates;
 
+        public LinkedList<EventInformation<TEvent>> Events { get; } = new LinkedList<EventInformation<TEvent>>();
+
         public void ForEach(Action<IExtensionInternal<TState, TEvent>> action)
         {
             this.Extensions.ForEach(action);

--- a/source/Appccelerate.StateMachine/Machine/StateContainer.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateContainer.cs
@@ -44,13 +44,13 @@ namespace Appccelerate.StateMachine.Machine
 
         public string Name { get; }
 
-        public List<IExtension<TState, TEvent>> Extensions { get; } = new List<IExtension<TState, TEvent>>();
+        public List<IExtensionInternal<TState, TEvent>> Extensions { get; } = new List<IExtensionInternal<TState, TEvent>>();
 
         public IInitializable<TState> CurrentStateId { get; set; }
 
         public IReadOnlyDictionary<TState, TState> LastActiveStates => this.lastActiveStates;
 
-        public void ForEach(Action<IExtension<TState, TEvent>> action)
+        public void ForEach(Action<IExtensionInternal<TState, TEvent>> action)
         {
             this.Extensions.ForEach(action);
         }

--- a/source/Appccelerate.StateMachine/Machine/StateContainer.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateContainer.cs
@@ -40,16 +40,14 @@ namespace Appccelerate.StateMachine.Machine
         public StateContainer(string name)
         {
             this.Name = name;
-            this.CurrentState = Initializable<IStateDefinition<TState, TEvent>>.UnInitialized();
+            this.CurrentStateId = Initializable<TState>.UnInitialized();
         }
 
         public string Name { get; }
 
         public List<IExtension<TState, TEvent>> Extensions { get; } = new List<IExtension<TState, TEvent>>();
 
-        public Initializable<IStateDefinition<TState, TEvent>> CurrentState { get; set; }
-
-        public IInitializable<TState> CurrentStateId => this.CurrentState.Map(x => x.Id);
+        public IInitializable<TState> CurrentStateId { get; set; }
 
         public IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> LastActiveStates => this.lastActiveStates;
 

--- a/source/Appccelerate.StateMachine/Machine/StateContainer.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateContainer.cs
@@ -50,7 +50,9 @@ namespace Appccelerate.StateMachine.Machine
 
         public IReadOnlyDictionary<TState, TState> LastActiveStates => this.lastActiveStates;
 
-        public LinkedList<EventInformation<TEvent>> Events { get; } = new LinkedList<EventInformation<TEvent>>();
+        public LinkedList<EventInformation<TEvent>> Events { get; set; } = new LinkedList<EventInformation<TEvent>>();
+
+        public IReadOnlyCollection<EventInformation<TEvent>> SaveableEvents => new List<EventInformation<TEvent>>(this.Events);
 
         public void ForEach(Action<IExtensionInternal<TState, TEvent>> action)
         {

--- a/source/Appccelerate.StateMachine/Machine/StateContainer.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateContainer.cs
@@ -21,16 +21,15 @@ namespace Appccelerate.StateMachine.Machine
     using System;
     using System.Collections.Generic;
     using Infrastructure;
-    using States;
 
     public class StateContainer<TState, TEvent> :
         IExtensionHost<TState, TEvent>,
         IStateMachineInformation<TState, TEvent>,
-        ILastActiveStateModifier<TState, TEvent>
+        ILastActiveStateModifier<TState>
         where TState : IComparable
         where TEvent : IComparable
     {
-        private readonly Dictionary<TState, IStateDefinition<TState, TEvent>> lastActiveStates = new Dictionary<TState, IStateDefinition<TState, TEvent>>();
+        private readonly Dictionary<TState, TState> lastActiveStates = new Dictionary<TState, TState>();
 
         public StateContainer()
             : this(default(string))
@@ -49,20 +48,22 @@ namespace Appccelerate.StateMachine.Machine
 
         public IInitializable<TState> CurrentStateId { get; set; }
 
-        public IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> LastActiveStates => this.lastActiveStates;
+        public IReadOnlyDictionary<TState, TState> LastActiveStates => this.lastActiveStates;
 
         public void ForEach(Action<IExtension<TState, TEvent>> action)
         {
             this.Extensions.ForEach(action);
         }
 
-        public IStateDefinition<TState, TEvent> GetLastActiveStateOrNullFor(TState state)
+        public Optional<TState> GetLastActiveStateFor(TState state)
         {
-            this.lastActiveStates.TryGetValue(state, out var lastActiveState);
-            return lastActiveState;
+            return
+                this.lastActiveStates.TryGetValue(state, out var lastActiveState)
+                    ? Optional<TState>.Just(lastActiveState)
+                    : Optional<TState>.Nothing();
         }
 
-        public void SetLastActiveStateFor(TState state, IStateDefinition<TState, TEvent> newLastActiveState)
+        public void SetLastActiveStateFor(TState state, TState newLastActiveState)
         {
             if (this.lastActiveStates.ContainsKey(state))
             {

--- a/source/Appccelerate.StateMachine/Machine/StateMachine.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateMachine.cs
@@ -145,7 +145,7 @@ namespace Appccelerate.StateMachine.Machine
                 .Map(x => stateDefinitions[x])
                 .ExtractOrThrow();
             var context = this.factory.CreateTransitionContext(currentState, new Missable<TEvent>(eventId), eventArgument, this);
-            var result = this.stateLogic.Fire(currentState, context, stateContainer);
+            var result = this.stateLogic.Fire(currentState, context, stateContainer, stateDefinitions);
 
             if (!result.Fired)
             {
@@ -221,7 +221,7 @@ namespace Appccelerate.StateMachine.Machine
         {
             var initialState = stateDefinitions[initialStateId];
             var initializer = this.factory.CreateStateMachineInitializer(initialState, context);
-            var newStateId = initializer.EnterInitialState(this.stateLogic, stateContainer);
+            var newStateId = initializer.EnterInitialState(this.stateLogic, stateContainer, stateDefinitions);
             var newStateDefinition = stateDefinitions[newStateId];
             SwitchStateTo(newStateDefinition, stateContainer, stateMachineInformation, stateDefinitions);
         }

--- a/source/Appccelerate.StateMachine/Machine/StateMachineDefinition.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateMachineDefinition.cs
@@ -28,12 +28,12 @@ namespace Appccelerate.StateMachine.Machine
         where TEvent : IComparable
     {
         private readonly IStateDefinitionDictionary<TState, TEvent> stateDefinitions;
-        private readonly IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates;
+        private readonly IReadOnlyDictionary<TState, TState> initiallyLastActiveStates;
         private readonly TState initialState;
 
         public StateMachineDefinition(
             IStateDefinitionDictionary<TState, TEvent> stateDefinitions,
-            IReadOnlyDictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates,
+            IReadOnlyDictionary<TState, TState> initiallyLastActiveStates,
             TState initialState)
         {
             this.stateDefinitions = stateDefinitions;
@@ -56,7 +56,7 @@ namespace Appccelerate.StateMachine.Machine
             }
 
             var transitionLogic = new TransitionLogic<TState, TEvent>(stateContainer, stateContainer);
-            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, stateContainer, stateContainer);
+            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, stateContainer, stateContainer, this.stateDefinitions);
             transitionLogic.SetStateLogic(stateLogic);
 
             var standardFactory = new StandardFactory<TState, TEvent>();
@@ -80,7 +80,7 @@ namespace Appccelerate.StateMachine.Machine
             }
 
             var transitionLogic = new TransitionLogic<TState, TEvent>(stateContainer, stateContainer);
-            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, stateContainer, stateContainer);
+            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, stateContainer, stateContainer, this.stateDefinitions);
             transitionLogic.SetStateLogic(stateLogic);
 
             var standardFactory = new StandardFactory<TState, TEvent>();

--- a/source/Appccelerate.StateMachine/Machine/StateMachineDefinition.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateMachineDefinition.cs
@@ -56,7 +56,7 @@ namespace Appccelerate.StateMachine.Machine
             }
 
             var transitionLogic = new TransitionLogic<TState, TEvent>(stateContainer, stateContainer);
-            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, stateContainer, stateContainer, this.stateDefinitions);
+            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, stateContainer, stateContainer);
             transitionLogic.SetStateLogic(stateLogic);
 
             var standardFactory = new StandardFactory<TState, TEvent>();
@@ -80,7 +80,7 @@ namespace Appccelerate.StateMachine.Machine
             }
 
             var transitionLogic = new TransitionLogic<TState, TEvent>(stateContainer, stateContainer);
-            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, stateContainer, stateContainer, this.stateDefinitions);
+            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, stateContainer, stateContainer);
             transitionLogic.SetStateLogic(stateLogic);
 
             var standardFactory = new StandardFactory<TState, TEvent>();

--- a/source/Appccelerate.StateMachine/Machine/StateMachineDefinition.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateMachineDefinition.cs
@@ -55,8 +55,8 @@ namespace Appccelerate.StateMachine.Machine
                 stateContainer.SetLastActiveStateFor(stateIdAndLastActiveState.Key, stateIdAndLastActiveState.Value);
             }
 
-            var transitionLogic = new TransitionLogic<TState, TEvent>(stateContainer, stateContainer);
-            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, stateContainer, stateContainer);
+            var transitionLogic = new TransitionLogic<TState, TEvent>(stateContainer);
+            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, stateContainer);
             transitionLogic.SetStateLogic(stateLogic);
 
             var standardFactory = new StandardFactory<TState, TEvent>();
@@ -79,8 +79,8 @@ namespace Appccelerate.StateMachine.Machine
                 stateContainer.SetLastActiveStateFor(stateIdAndLastActiveState.Key, stateIdAndLastActiveState.Value);
             }
 
-            var transitionLogic = new TransitionLogic<TState, TEvent>(stateContainer, stateContainer);
-            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, stateContainer, stateContainer);
+            var transitionLogic = new TransitionLogic<TState, TEvent>(stateContainer);
+            var stateLogic = new StateLogic<TState, TEvent>(transitionLogic, stateContainer);
             transitionLogic.SetStateLogic(stateLogic);
 
             var standardFactory = new StandardFactory<TState, TEvent>();

--- a/source/Appccelerate.StateMachine/Machine/StateMachineDefinitionBuilder.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateMachineDefinitionBuilder.cs
@@ -20,7 +20,6 @@ namespace Appccelerate.StateMachine.Machine
 {
     using System;
     using System.Collections.Generic;
-    using States;
     using Syntax;
 
     public class StateMachineDefinitionBuilder<TState, TEvent>
@@ -29,7 +28,7 @@ namespace Appccelerate.StateMachine.Machine
     {
         private readonly StandardFactory<TState, TEvent> factory = new StandardFactory<TState, TEvent>();
         private readonly ImplicitAddIfNotAvailableStateDefinitionDictionary<TState, TEvent> stateDefinitionDictionary = new ImplicitAddIfNotAvailableStateDefinitionDictionary<TState, TEvent>();
-        private readonly Dictionary<TState, IStateDefinition<TState, TEvent>> initiallyLastActiveStates = new Dictionary<TState, IStateDefinition<TState, TEvent>>();
+        private readonly Dictionary<TState, TState> initiallyLastActiveStates = new Dictionary<TState, TState>();
         private TState initialState;
         private bool isInitialStateConfigured;
 

--- a/source/Appccelerate.StateMachine/Machine/StateMachineInitializer.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateMachineInitializer.cs
@@ -45,12 +45,13 @@ namespace Appccelerate.StateMachine.Machine
 
         public TState EnterInitialState(
             IStateLogic<TState, TEvent> stateLogic,
-            ILastActiveStateModifier<TState> lastActiveStateModifier)
+            ILastActiveStateModifier<TState> lastActiveStateModifier,
+            IStateDefinitionDictionary<TState, TEvent> stateDefinitions)
         {
             var stack = this.TraverseUpTheStateHierarchy();
             this.TraverseDownTheStateHierarchyAndEnterStates(stateLogic, stack);
 
-            return stateLogic.EnterByHistory(this.initialState, this.context, lastActiveStateModifier);
+            return stateLogic.EnterByHistory(this.initialState, this.context, lastActiveStateModifier, stateDefinitions);
         }
 
         /// <summary>

--- a/source/Appccelerate.StateMachine/Machine/StateMachineInitializer.cs
+++ b/source/Appccelerate.StateMachine/Machine/StateMachineInitializer.cs
@@ -45,7 +45,7 @@ namespace Appccelerate.StateMachine.Machine
 
         public TState EnterInitialState(
             IStateLogic<TState, TEvent> stateLogic,
-            ILastActiveStateModifier<TState, TEvent> lastActiveStateModifier)
+            ILastActiveStateModifier<TState> lastActiveStateModifier)
         {
             var stack = this.TraverseUpTheStateHierarchy();
             this.TraverseDownTheStateHierarchyAndEnterStates(stateLogic, stack);

--- a/source/Appccelerate.StateMachine/Machine/States/IStateLogic.cs
+++ b/source/Appccelerate.StateMachine/Machine/States/IStateLogic.cs
@@ -30,13 +30,14 @@ namespace Appccelerate.StateMachine.Machine.States
         /// <param name="stateDefinition">The definition of the state onto which the event should be fired.</param>
         /// <param name="context">The event context.</param>
         /// <param name="lastActiveStateModifier">The last active state modifier.</param>
+        /// <param name="stateDefinitions">The definitions for all states of this state Machine.</param>
         /// <returns>The result of the transition.</returns>
-        ITransitionResult<TState> Fire(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context, ILastActiveStateModifier<TState> lastActiveStateModifier);
+        ITransitionResult<TState> Fire(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context, ILastActiveStateModifier<TState> lastActiveStateModifier, IStateDefinitionDictionary<TState, TEvent> stateDefinitions);
 
         void Entry(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context);
 
         void Exit(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context, ILastActiveStateModifier<TState> lastActiveStateModifier);
 
-        TState EnterByHistory(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context, ILastActiveStateModifier<TState> lastActiveStateModifier);
+        TState EnterByHistory(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context, ILastActiveStateModifier<TState> lastActiveStateModifier, IStateDefinitionDictionary<TState, TEvent> stateDefinitions);
     }
 }

--- a/source/Appccelerate.StateMachine/Machine/States/IStateLogic.cs
+++ b/source/Appccelerate.StateMachine/Machine/States/IStateLogic.cs
@@ -31,12 +31,12 @@ namespace Appccelerate.StateMachine.Machine.States
         /// <param name="context">The event context.</param>
         /// <param name="lastActiveStateModifier">The last active state modifier.</param>
         /// <returns>The result of the transition.</returns>
-        ITransitionResult<TState> Fire(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context, ILastActiveStateModifier<TState, TEvent> lastActiveStateModifier);
+        ITransitionResult<TState> Fire(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context, ILastActiveStateModifier<TState> lastActiveStateModifier);
 
         void Entry(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context);
 
-        void Exit(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context, ILastActiveStateModifier<TState, TEvent> lastActiveStateModifier);
+        void Exit(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context, ILastActiveStateModifier<TState> lastActiveStateModifier);
 
-        TState EnterByHistory(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context, ILastActiveStateModifier<TState, TEvent> lastActiveStateModifier);
+        TState EnterByHistory(IStateDefinition<TState, TEvent> stateDefinition, ITransitionContext<TState, TEvent> context, ILastActiveStateModifier<TState> lastActiveStateModifier);
     }
 }

--- a/source/Appccelerate.StateMachine/Machine/States/StateLogic.cs
+++ b/source/Appccelerate.StateMachine/Machine/States/StateLogic.cs
@@ -28,16 +28,13 @@ namespace Appccelerate.StateMachine.Machine.States
         where TEvent : IComparable
     {
         private readonly IExtensionHost<TState, TEvent> extensionHost;
-        private readonly IStateMachineInformation<TState, TEvent> stateMachineInformation;
         private readonly ITransitionLogic<TState, TEvent> transitionLogic;
 
         public StateLogic(
             ITransitionLogic<TState, TEvent> transitionLogic,
-            IExtensionHost<TState, TEvent> extensionHost,
-            IStateMachineInformation<TState, TEvent> stateMachineInformation)
+            IExtensionHost<TState, TEvent> extensionHost)
         {
             this.extensionHost = extensionHost;
-            this.stateMachineInformation = stateMachineInformation;
             this.transitionLogic = transitionLogic;
         }
 
@@ -204,15 +201,13 @@ namespace Appccelerate.StateMachine.Machine.States
         {
             this.extensionHost.ForEach(
                 extension =>
-                extension.HandlingEntryActionException(
-                    this.stateMachineInformation, stateDefinition, context, ref exception));
+                extension.HandlingEntryActionException(stateDefinition, context, ref exception));
 
             HandleException(exception, context);
 
             this.extensionHost.ForEach(
                 extension =>
-                extension.HandledEntryActionException(
-                    this.stateMachineInformation, stateDefinition, context, exception));
+                extension.HandledEntryActionException(stateDefinition, context, exception));
         }
 
         private void ExecuteExitActions(
@@ -247,15 +242,13 @@ namespace Appccelerate.StateMachine.Machine.States
         {
             this.extensionHost.ForEach(
                 extension =>
-                extension.HandlingExitActionException(
-                    this.stateMachineInformation, stateDefinition, context, ref exception));
+                extension.HandlingExitActionException(stateDefinition, context, ref exception));
 
             HandleException(exception, context);
 
             this.extensionHost.ForEach(
                 extension =>
-                extension.HandledExitActionException(
-                    this.stateMachineInformation, stateDefinition, context, exception));
+                extension.HandledExitActionException(stateDefinition, context, exception));
         }
 
         /// <summary>

--- a/source/Appccelerate.StateMachine/Machine/States/StateLogic.cs
+++ b/source/Appccelerate.StateMachine/Machine/States/StateLogic.cs
@@ -86,8 +86,7 @@ namespace Appccelerate.StateMachine.Machine.States
 
             this.extensionHost.ForEach(
                 extension =>
-                    extension.EnteringState(
-                        this.stateMachineInformation, stateDefinition, context));
+                    extension.EnteringState(stateDefinition, context));
 
             this.ExecuteEntryActions(stateDefinition, context);
         }

--- a/source/Appccelerate.StateMachine/Machine/Transitions/ITransitionLogic.cs
+++ b/source/Appccelerate.StateMachine/Machine/Transitions/ITransitionLogic.cs
@@ -29,11 +29,13 @@ namespace Appccelerate.StateMachine.Machine.Transitions
         /// </summary>
         /// <param name="transitionDefinition">The definition of the transition which should happen.</param>
         /// <param name="context">The event context.</param>
-        /// <returns>The result of the transition.</returns>
         /// <param name="lastActiveStateModifier">The last active state modifier.</param>
+        /// <param name="stateDefinitions">The definitions for all states of this state Machine.</param>
+        /// <returns>The result of the transition.</returns>
         ITransitionResult<TState> Fire(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> context,
-            ILastActiveStateModifier<TState> lastActiveStateModifier);
+            ILastActiveStateModifier<TState> lastActiveStateModifier,
+            IStateDefinitionDictionary<TState, TEvent> stateDefinitions);
     }
 }

--- a/source/Appccelerate.StateMachine/Machine/Transitions/ITransitionLogic.cs
+++ b/source/Appccelerate.StateMachine/Machine/Transitions/ITransitionLogic.cs
@@ -34,6 +34,6 @@ namespace Appccelerate.StateMachine.Machine.Transitions
         ITransitionResult<TState> Fire(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> context,
-            ILastActiveStateModifier<TState, TEvent> lastActiveStateModifier);
+            ILastActiveStateModifier<TState> lastActiveStateModifier);
     }
 }

--- a/source/Appccelerate.StateMachine/Machine/Transitions/TransitionLogic.cs
+++ b/source/Appccelerate.StateMachine/Machine/Transitions/TransitionLogic.cs
@@ -47,7 +47,7 @@ namespace Appccelerate.StateMachine.Machine.Transitions
         public ITransitionResult<TState> Fire(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> context,
-            ILastActiveStateModifier<TState, TEvent> lastActiveStateModifier)
+            ILastActiveStateModifier<TState> lastActiveStateModifier)
         {
             Guard.AgainstNullArgument("context", context);
 
@@ -137,7 +137,7 @@ namespace Appccelerate.StateMachine.Machine.Transitions
             IStateDefinition<TState, TEvent> source,
             IStateDefinition<TState, TEvent> target,
             ITransitionContext<TState, TEvent> context,
-            ILastActiveStateModifier<TState, TEvent> lastActiveStateModifier)
+            ILastActiveStateModifier<TState> lastActiveStateModifier)
         {
             if (source == transitionDefinition.Target)
             {
@@ -234,7 +234,7 @@ namespace Appccelerate.StateMachine.Machine.Transitions
         private void UnwindSubStates(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> context,
-            ILastActiveStateModifier<TState, TEvent> lastActiveStateModifier)
+            ILastActiveStateModifier<TState> lastActiveStateModifier)
         {
             var o = context.StateDefinition;
             while (o != transitionDefinition.Source)

--- a/source/Appccelerate.StateMachine/Machine/Transitions/TransitionLogic.cs
+++ b/source/Appccelerate.StateMachine/Machine/Transitions/TransitionLogic.cs
@@ -27,16 +27,12 @@ namespace Appccelerate.StateMachine.Machine.Transitions
         where TEvent : IComparable
     {
         private readonly IExtensionHost<TState, TEvent> extensionHost;
-        private readonly IStateMachineInformation<TState, TEvent> stateMachineInformation;
 
         private IStateLogic<TState, TEvent> stateLogic;
 
-        public TransitionLogic(
-            IExtensionHost<TState, TEvent> extensionHost,
-            IStateMachineInformation<TState, TEvent> stateMachineInformation)
+        public TransitionLogic(IExtensionHost<TState, TEvent> extensionHost)
         {
             this.extensionHost = extensionHost;
-            this.stateMachineInformation = stateMachineInformation;
         }
 
         public void SetStateLogic(IStateLogic<TState, TEvent> stateLogicToSet)
@@ -54,20 +50,16 @@ namespace Appccelerate.StateMachine.Machine.Transitions
 
             if (!this.ShouldFire(transitionDefinition, context))
             {
-                this.extensionHost.ForEach(extension => extension.SkippedTransition(
-                    this.stateMachineInformation,
-                    transitionDefinition,
-                    context));
+                this.extensionHost.ForEach(extension =>
+                    extension.SkippedTransition(transitionDefinition, context));
 
                 return TransitionResult<TState>.NotFired;
             }
 
             context.OnTransitionBegin();
 
-            this.extensionHost.ForEach(extension => extension.ExecutingTransition(
-                this.stateMachineInformation,
-                transitionDefinition,
-                context));
+            this.extensionHost.ForEach(extension =>
+                extension.ExecutingTransition(transitionDefinition, context));
 
             var newState = context.StateDefinition.Id;
 
@@ -84,10 +76,8 @@ namespace Appccelerate.StateMachine.Machine.Transitions
                 this.PerformActions(transitionDefinition, context);
             }
 
-            this.extensionHost.ForEach(extension => extension.ExecutedTransition(
-                this.stateMachineInformation,
-                transitionDefinition,
-                context));
+            this.extensionHost.ForEach(extension =>
+                extension.ExecutedTransition(transitionDefinition, context));
 
             return new TransitionResult<TState>(true, newState);
         }
@@ -200,12 +190,12 @@ namespace Appccelerate.StateMachine.Machine.Transitions
             catch (Exception exception)
             {
                 this.extensionHost.ForEach(extension =>
-                    extension.HandlingGuardException(this.stateMachineInformation, transitionDefinition, context, ref exception));
+                    extension.HandlingGuardException(transitionDefinition, context, ref exception));
 
                 HandleException(exception, context);
 
                 this.extensionHost.ForEach(extension =>
-                    extension.HandledGuardException(this.stateMachineInformation, transitionDefinition, context, exception));
+                    extension.HandledGuardException(transitionDefinition, context, exception));
 
                 return false;
             }
@@ -222,12 +212,12 @@ namespace Appccelerate.StateMachine.Machine.Transitions
                 catch (Exception exception)
                 {
                     this.extensionHost.ForEach(extension =>
-                        extension.HandlingTransitionException(this.stateMachineInformation, transitionDefinition, context, ref exception));
+                        extension.HandlingTransitionException(transitionDefinition, context, ref exception));
 
                     HandleException(exception, context);
 
                     this.extensionHost.ForEach(extension =>
-                        extension.HandledTransitionException(this.stateMachineInformation, transitionDefinition, context, exception));
+                        extension.HandledTransitionException(transitionDefinition, context, exception));
                 }
             }
         }

--- a/source/Appccelerate.StateMachine/Machine/Transitions/TransitionLogic.cs
+++ b/source/Appccelerate.StateMachine/Machine/Transitions/TransitionLogic.cs
@@ -47,7 +47,8 @@ namespace Appccelerate.StateMachine.Machine.Transitions
         public ITransitionResult<TState> Fire(
             ITransitionDefinition<TState, TEvent> transitionDefinition,
             ITransitionContext<TState, TEvent> context,
-            ILastActiveStateModifier<TState> lastActiveStateModifier)
+            ILastActiveStateModifier<TState> lastActiveStateModifier,
+            IStateDefinitionDictionary<TState, TEvent> stateDefinitions)
         {
             Guard.AgainstNullArgument("context", context);
 
@@ -76,7 +77,7 @@ namespace Appccelerate.StateMachine.Machine.Transitions
 
                 this.Fire(transitionDefinition, transitionDefinition.Source, transitionDefinition.Target, context, lastActiveStateModifier);
 
-                newState = this.stateLogic.EnterByHistory(transitionDefinition.Target, context, lastActiveStateModifier);
+                newState = this.stateLogic.EnterByHistory(transitionDefinition.Target, context, lastActiveStateModifier, stateDefinitions);
             }
             else
             {

--- a/source/Appccelerate.StateMachine/PassiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/PassiveStateMachine.cs
@@ -233,10 +233,7 @@ namespace Appccelerate.StateMachine
             stateMachineSaver.SaveCurrentState(this.stateContainer.CurrentStateId);
 
             var historyStates = this.stateContainer
-                .LastActiveStates
-                .ToDictionary(
-                    pair => pair.Key,
-                    pair => pair.Value.Id);
+                .LastActiveStates;
 
             stateMachineSaver.SaveHistoryStates(historyStates);
         }
@@ -269,9 +266,14 @@ namespace Appccelerate.StateMachine
                 foreach (var historyState in historyStates)
                 {
                     var superState = this.stateDefinitions[historyState.Key];
-                    var lastActiveState = this.stateDefinitions[historyState.Value];
+                    var lastActiveState = historyState.Value;
 
-                    if (!superState.SubStates.Contains(lastActiveState))
+                    var lastActiveStateIsNotASubStateOfSuperState = superState
+                                                                        .SubStates
+                                                                        .Select(x => x.Id)
+                                                                        .Contains(lastActiveState)
+                                                                    == false;
+                    if (lastActiveStateIsNotASubStateOfSuperState)
                     {
                         throw new InvalidOperationException(ExceptionMessages.CannotSetALastActiveStateThatIsNotASubState);
                     }

--- a/source/Appccelerate.StateMachine/PassiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/PassiveStateMachine.cs
@@ -21,6 +21,7 @@ namespace Appccelerate.StateMachine
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Extensions;
     using Machine;
     using Machine.Events;
     using Persistence;
@@ -133,7 +134,7 @@ namespace Appccelerate.StateMachine
         {
             this.events.AddLast(new EventInformation<TEvent>(eventId, eventArgument));
 
-            this.stateContainer.ForEach(extension => extension.EventQueued(this.stateContainer, eventId, eventArgument));
+            this.stateContainer.ForEach(extension => extension.EventQueued(eventId, eventArgument));
 
             this.Execute();
         }
@@ -156,7 +157,7 @@ namespace Appccelerate.StateMachine
         {
             this.events.AddFirst(new EventInformation<TEvent>(eventId, eventArgument));
 
-            this.stateContainer.ForEach(extension => extension.EventQueuedWithPriority(this.stateContainer, eventId, eventArgument));
+            this.stateContainer.ForEach(extension => extension.EventQueuedWithPriority(eventId, eventArgument));
 
             this.Execute();
         }
@@ -170,7 +171,7 @@ namespace Appccelerate.StateMachine
         {
             this.IsRunning = true;
 
-            this.stateContainer.ForEach(extension => extension.StartedStateMachine(this.stateContainer));
+            this.stateContainer.ForEach(extension => extension.StartedStateMachine());
 
             this.Execute();
         }
@@ -202,7 +203,7 @@ namespace Appccelerate.StateMachine
         {
             this.IsRunning = false;
 
-            this.stateContainer.ForEach(extension => extension.StoppedStateMachine(this.stateContainer));
+            this.stateContainer.ForEach(extension => extension.StoppedStateMachine());
         }
 
         /// <summary>
@@ -211,7 +212,8 @@ namespace Appccelerate.StateMachine
         /// <param name="extension">The extension.</param>
         public void AddExtension(IExtension<TState, TEvent> extension)
         {
-            this.stateContainer.Extensions.Add(extension);
+            var extensionCompose = new InternalExtension<TState, TEvent>(extension, this.stateContainer);
+            this.stateContainer.Extensions.Add(extensionCompose);
         }
 
         /// <summary>
@@ -286,7 +288,6 @@ namespace Appccelerate.StateMachine
             {
                 this.stateContainer.Extensions.ForEach(
                     extension => extension.Loaded(
-                        this.stateContainer,
                         loadedCurrentState,
                         historyStates));
             }
@@ -342,7 +343,7 @@ namespace Appccelerate.StateMachine
                 return;
             }
 
-            this.stateMachine.EnterInitialState(this.stateContainer, this.stateContainer, this.stateDefinitions, this.initialState);
+            this.stateMachine.EnterInitialState(this.stateContainer, this.stateDefinitions, this.initialState);
         }
 
         /// <summary>
@@ -362,7 +363,7 @@ namespace Appccelerate.StateMachine
         /// <param name="e">The event to fire.</param>
         private void FireEventOnStateMachine(EventInformation<TEvent> e)
         {
-            this.stateMachine.Fire(e.EventId, e.EventArgument, this.stateContainer, this.stateContainer, this.stateDefinitions);
+            this.stateMachine.Fire(e.EventId, e.EventArgument, this.stateContainer, this.stateDefinitions);
         }
     }
 }

--- a/source/Appccelerate.StateMachine/PassiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/PassiveStateMachine.cs
@@ -261,7 +261,7 @@ namespace Appccelerate.StateMachine
 
             void SetCurrentState()
             {
-                this.stateContainer.CurrentState = loadedCurrentState.Map(x => this.stateDefinitions[x]);
+                this.stateContainer.CurrentStateId = loadedCurrentState;
             }
 
             void LoadHistoryStates()
@@ -292,7 +292,7 @@ namespace Appccelerate.StateMachine
 
         private void CheckThatNotAlreadyInitialized()
         {
-            if (this.stateContainer.CurrentState.IsInitialized)
+            if (this.stateContainer.CurrentStateId.IsInitialized)
             {
                 throw new InvalidOperationException(ExceptionMessages.StateMachineIsAlreadyInitialized);
             }
@@ -335,7 +335,7 @@ namespace Appccelerate.StateMachine
 
         private void InitializeStateMachineIfInitializationIsPending()
         {
-            if (this.stateContainer.CurrentState.IsInitialized)
+            if (this.stateContainer.CurrentStateId.IsInitialized)
             {
                 return;
             }

--- a/source/Appccelerate.StateMachine/PassiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/PassiveStateMachine.cs
@@ -19,7 +19,6 @@
 namespace Appccelerate.StateMachine
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using Extensions;
     using Machine;
@@ -42,11 +41,6 @@ namespace Appccelerate.StateMachine
         /// </summary>
         private readonly StateMachine<TState, TEvent> stateMachine;
 
-        /// <summary>
-        /// List of all queued events.
-        /// </summary>
-        private readonly LinkedList<EventInformation<TEvent>> events;
-
         private readonly StateContainer<TState, TEvent> stateContainer;
 
         private readonly IStateDefinitionDictionary<TState, TEvent> stateDefinitions;
@@ -68,7 +62,6 @@ namespace Appccelerate.StateMachine
             this.stateContainer = stateContainer;
             this.stateDefinitions = stateDefinitions;
             this.initialState = initialState;
-            this.events = new LinkedList<EventInformation<TEvent>>();
         }
 
         /// <summary>
@@ -132,7 +125,7 @@ namespace Appccelerate.StateMachine
         /// <param name="eventArgument">The event argument.</param>
         public void Fire(TEvent eventId, object eventArgument)
         {
-            this.events.AddLast(new EventInformation<TEvent>(eventId, eventArgument));
+            this.stateContainer.Events.AddLast(new EventInformation<TEvent>(eventId, eventArgument));
 
             this.stateContainer.ForEach(extension => extension.EventQueued(eventId, eventArgument));
 
@@ -155,7 +148,7 @@ namespace Appccelerate.StateMachine
         /// <param name="eventArgument">The event argument.</param>
         public void FirePriority(TEvent eventId, object eventArgument)
         {
-            this.events.AddFirst(new EventInformation<TEvent>(eventId, eventArgument));
+            this.stateContainer.Events.AddFirst(new EventInformation<TEvent>(eventId, eventArgument));
 
             this.stateContainer.ForEach(extension => extension.EventQueuedWithPriority(eventId, eventArgument));
 
@@ -329,7 +322,7 @@ namespace Appccelerate.StateMachine
         {
             this.InitializeStateMachineIfInitializationIsPending();
 
-            while (this.events.Count > 0)
+            while (this.stateContainer.Events.Count > 0)
             {
                 var eventToProcess = this.GetNextEventToProcess();
                 this.FireEventOnStateMachine(eventToProcess);
@@ -352,8 +345,8 @@ namespace Appccelerate.StateMachine
         /// <returns>The next queued event.</returns>
         private EventInformation<TEvent> GetNextEventToProcess()
         {
-            var e = this.events.First.Value;
-            this.events.RemoveFirst();
+            var e = this.stateContainer.Events.First.Value;
+            this.stateContainer.Events.RemoveFirst();
             return e;
         }
 

--- a/source/Appccelerate.StateMachine/PassiveStateMachine.cs
+++ b/source/Appccelerate.StateMachine/PassiveStateMachine.cs
@@ -289,7 +289,8 @@ namespace Appccelerate.StateMachine
                 this.stateContainer.Extensions.ForEach(
                     extension => extension.Loaded(
                         loadedCurrentState,
-                        historyStates));
+                        historyStates,
+                        events));
             }
         }
 

--- a/source/Appccelerate.StateMachine/Persistence/IAsyncStateMachineLoader.cs
+++ b/source/Appccelerate.StateMachine/Persistence/IAsyncStateMachineLoader.cs
@@ -23,8 +23,9 @@ namespace Appccelerate.StateMachine.Persistence
     using System.Threading.Tasks;
     using Infrastructure;
 
-    public interface IAsyncStateMachineLoader<TState>
+    public interface IAsyncStateMachineLoader<TState, TEvent>
         where TState : IComparable
+        where TEvent : IComparable
     {
         /// <summary>
         /// Returns the state to be set as the current state of the state machine.
@@ -37,5 +38,17 @@ namespace Appccelerate.StateMachine.Persistence
         /// </summary>
         /// <returns>Key = id of super state, Value = id of last active state.</returns>
         Task<IReadOnlyDictionary<TState, TState>> LoadHistoryStates();
+
+        /// <summary>
+        /// Returns the events to be processed by the state machine.
+        /// </summary>
+        /// <returns>The events.</returns>
+        Task<IReadOnlyCollection<EventInformation<TEvent>>> LoadEvents();
+
+        /// <summary>
+        /// Returns the priority events to be processed by the state machine.
+        /// </summary>
+        /// <returns>The priority events.</returns>
+        Task<IReadOnlyCollection<EventInformation<TEvent>>> LoadPriorityEvents();
     }
 }

--- a/source/Appccelerate.StateMachine/Persistence/IAsyncStateMachineSaver.cs
+++ b/source/Appccelerate.StateMachine/Persistence/IAsyncStateMachineSaver.cs
@@ -23,8 +23,9 @@ namespace Appccelerate.StateMachine.Persistence
     using System.Threading.Tasks;
     using Infrastructure;
 
-    public interface IAsyncStateMachineSaver<TState>
+    public interface IAsyncStateMachineSaver<TState, TEvent>
         where TState : IComparable
+        where TEvent : IComparable
     {
         /// <summary>
         /// Saves the current state of the state machine.
@@ -39,5 +40,19 @@ namespace Appccelerate.StateMachine.Persistence
         /// <param name="historyStates">Key = id of the super state; Value = if of last active state of super state.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task SaveHistoryStates(IReadOnlyDictionary<TState, TState> historyStates);
+
+        /// <summary>
+        /// Saves the not yet processed events of the state machine.
+        /// </summary>
+        /// <param name="events">The not yet processed events.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task SaveEvents(IReadOnlyCollection<EventInformation<TEvent>> events);
+
+        /// <summary>
+        /// Saves the not yet processed priority events of the state machine.
+        /// </summary>
+        /// <param name="priorityEvents">The not yet processed priority events.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task SavePriorityEvents(IReadOnlyCollection<EventInformation<TEvent>> priorityEvents);
     }
 }

--- a/source/Appccelerate.StateMachine/Persistence/IStateMachineLoader.cs
+++ b/source/Appccelerate.StateMachine/Persistence/IStateMachineLoader.cs
@@ -22,8 +22,9 @@ namespace Appccelerate.StateMachine.Persistence
     using System.Collections.Generic;
     using Infrastructure;
 
-    public interface IStateMachineLoader<TState>
+    public interface IStateMachineLoader<TState, TEvent>
         where TState : IComparable
+        where TEvent : IComparable
     {
         /// <summary>
         /// Returns the state to be set as the current state of the state machine.
@@ -36,5 +37,11 @@ namespace Appccelerate.StateMachine.Persistence
         /// </summary>
         /// <returns>Key = id of super state, Value = id of last active state.</returns>
         IReadOnlyDictionary<TState, TState> LoadHistoryStates();
+
+        /// <summary>
+        /// Returns the events to be processed by the state machine.
+        /// </summary>
+        /// <returns>The events.</returns>
+        IReadOnlyCollection<EventInformation<TEvent>> LoadEvents();
     }
 }

--- a/source/Appccelerate.StateMachine/Persistence/IStateMachineSaver.cs
+++ b/source/Appccelerate.StateMachine/Persistence/IStateMachineSaver.cs
@@ -22,8 +22,9 @@ namespace Appccelerate.StateMachine.Persistence
     using System.Collections.Generic;
     using Infrastructure;
 
-    public interface IStateMachineSaver<TState>
+    public interface IStateMachineSaver<TState, TEvent>
         where TState : IComparable
+        where TEvent : IComparable
     {
         /// <summary>
         /// Saves the current state of the state machine.
@@ -36,5 +37,11 @@ namespace Appccelerate.StateMachine.Persistence
         /// </summary>
         /// <param name="historyStates">Key = id of the super state; Value = if of last active state of super state.</param>
         void SaveHistoryStates(IReadOnlyDictionary<TState, TState> historyStates);
+
+        /// <summary>
+        /// Saves the not yet processed events of the state machine.
+        /// </summary>
+        /// <param name="events">The not yet processed events.</param>
+        void SaveEvents(IReadOnlyCollection<EventInformation<TEvent>> events);
     }
 }


### PR DESCRIPTION
With this PR all state (as in "mutable state" and not "state machine states") is moved to StateContainer.
This also includes pending events, which are now also saved / loaded.

## API changes:
The interface ```IStateMachineSaver``` got a new method ```void SaveEvents(IReadOnlyCollection<EventInformation<TEvent>> events)``` for saving pending events.
The complementing interface ```IStateMachineLoader``` got also a new method ```IReadOnlyCollection<EventInformation<TEvent>> LoadEvents()```.

Same goes for the Async versions of them.
But there are 2 new methods each. One for normal events and one for priority events.

## Internal changes:
### IExtensionInternal
There is a new interface ```IExtensionInternal``` interface that code will use. it is equivalent to the API interface ```IExtension``` apart from not requiring the ```IStateMachineInfo``` parameter. That parameter is already passed via constructor.

Reason: the ```IStateMachineInfo``` parameter had to be passed around much of the codebase just to pass it to the ```IExtension``` methods.

### Pending Events
Pending events were moved from the ```StateContainer``` to have all state at the same place.

### TState in StateContainer
Changed ```StateContainer.CurrentState``` to ```TState``` from ```IStateDefinition``` and removed ```StateContainer.CurrentStateId```.
Also change ```ILastActiveStateModifier``` to deal with ```TState```.

Reason: All savable "things" now use ```TState``` so when loading a StateMachine there are no issues with references to other ```IStateDefinitions```